### PR TITLE
Healthchecks need to hit the prefixed route

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,14 +23,14 @@ spec:
         livenessProbe:
           httpGet:
             port: http
-            path: /health
+            path: /climatology/health
           # If it fails 3 times in 30 seconds, it will be killed
           failureThreshold: 3
           periodSeconds: 10
         startupProbe:
           httpGet:
             port: http
-            path: /health
+            path: /climatology/health
           # If it fails 30 times in 300 seconds upon startup, it will be killed
           failureThreshold: 30
           periodSeconds: 10


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 8 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> #16 👈 
- <kbd>&nbsp;7&nbsp;</kbd> #15 
- <kbd>&nbsp;6&nbsp;</kbd> #12 
- <kbd>&nbsp;5&nbsp;</kbd> #11 
- <kbd>&nbsp;4&nbsp;</kbd> #10 
- <kbd>&nbsp;3&nbsp;</kbd> #9 
- <kbd>&nbsp;2&nbsp;</kbd> #6 
- <kbd>&nbsp;1&nbsp;</kbd> #4 
<!-- GitButler Footer Boundary Bottom -->

