### PR TITLE
Secret climatology platforms

### DIFF
--- a/climatology.py
+++ b/climatology.py
@@ -33,7 +33,7 @@ def _(pd):
 
 @app.cell
 def _(httpx):
-    platform_res = httpx.get("https://buoybarn.neracoos.org/api/platforms/")
+    platform_res = httpx.get("https://buoybarn.neracoos.org/api/platforms/?visibility=climatology")
     return (platform_res,)
 
 


### PR DESCRIPTION
Tweak the endpoint that is used so that it pulls from platforms that have been configured to show on the climatology dashboard. 

This way platforms can be hidden from Mariners that don't make sense. Similarly platforms can be hidden from climatology.