### PR TITLE
Remove the python setup step from pre-commit action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.13"
       - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5


### PR DESCRIPTION
Prek manages Python itself, so it doesn’t need Python to be setup first. 

Renovate might otherwise make some confused PRs https://github.com/gulfofmaine/climatology_py_dash/pull/61