### PR TITLE
Harden chart e2e tests against Vega resize re-render

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: ["--pytest-test-first"]
+        exclude: ^tests/e2e/helpers\.py$
       - id: requirements-txt-fixer
       - id: trailing-whitespace
       - id: no-commit-to-branch

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,0 +1,42 @@
+"""Shared helpers for the end-to-end Playwright tests."""
+
+import time
+
+from playwright.sync_api import Page, expect
+
+# A full-width chart is ~750px on the 1280px test viewport; the narrow-chart
+# regression (Vega's default when width isn't set to "container") is ~400px.
+# 600 cleanly separates the two.
+MIN_CHART_WIDTH = 600
+
+
+def assert_chart_rendered(page: Page, *, min_width: int = MIN_CHART_WIDTH) -> None:
+    """Assert the first vega chart rendered without errors and fills its container.
+
+    Vega renders once at a default width and then re-renders at the container
+    width via a resize observer, detaching and replacing the ``<canvas>`` in the
+    process. ``bounding_box()`` therefore transiently returns ``None`` (or a
+    pre-resize width) right after the canvas becomes visible, which is flaky on
+    slower CI runners. Poll until the width settles instead of sampling once.
+    """
+    expect(page.get_by_text("Duplicate signal name")).to_have_count(0)
+
+    chart = page.locator("canvas").first
+    expect(chart).to_be_visible(timeout=60000)
+
+    deadline = time.monotonic() + 60
+    stable_width = None
+    last_width = None
+    while time.monotonic() < deadline:
+        box = chart.bounding_box()
+        width = box["width"] if box else None
+        if width and width == last_width:
+            stable_width = width
+            break
+        last_width = width
+        page.wait_for_timeout(250)
+
+    assert stable_width is not None, "chart canvas never reported a stable width"
+    assert stable_width > min_width, (
+        f"chart width {stable_width} <= {min_width}; expected a full-width chart"
+    )

--- a/tests/e2e/test_by_platform.py
+++ b/tests/e2e/test_by_platform.py
@@ -1,3 +1,4 @@
+from helpers import assert_chart_rendered
 from playwright.sync_api import Page, expect
 
 
@@ -11,14 +12,7 @@ def test_western_maine_shelf(page: Page) -> None:
     page.get_by_role("option", name="Barometric Pressure").click()
     page.get_by_text("Resampled to weekly means for").click()
 
-    expect(page.get_by_text("Duplicate signal name")).to_have_count(0)
-    expect(page.locator("canvas").first).to_be_visible(timeout=60000)
-
-    chart = page.locator("canvas").first
-    expect(chart).to_be_visible(timeout=60000)
-    box = chart.bounding_box()
-    assert box is not None
-    assert box["width"] > 700
+    assert_chart_rendered(page)
 
     page.locator("summary").click()
 

--- a/tests/e2e/test_by_standard_name.py
+++ b/tests/e2e/test_by_standard_name.py
@@ -1,3 +1,4 @@
+from helpers import assert_chart_rendered
 from playwright.sync_api import Page, expect
 
 
@@ -20,11 +21,7 @@ def test_air_temp(page: Page) -> None:
 
     expect(page.get_by_text("Resampled to daily means for")).to_be_visible()
 
-    chart = page.locator("canvas").first
-    expect(chart).to_be_visible(timeout=60000)
-    box = chart.bounding_box()
-    assert box is not None
-    assert box["width"] > 700
+    assert_chart_rendered(page)
 
     page.get_by_role("group", name="Click to view actions").get_by_role("img").click()
     with page.expect_download() as download_info:

--- a/tests/e2e/test_climatology.py
+++ b/tests/e2e/test_climatology.py
@@ -2,6 +2,7 @@
 End-to-end tests for the Climatology page of the application.
 """
 
+from helpers import assert_chart_rendered
 from playwright.sync_api import Page, expect
 
 
@@ -15,12 +16,7 @@ def test_western_maine_shelf_air(page: Page) -> None:
         "/climatology/?platform=Western+Maine+Shelf&ts=Air+Temperature",
     )
 
-    expect(page.get_by_text("Duplicate signal name")).to_have_count(0)
-    chart = page.locator("canvas").first
-    expect(chart).to_be_visible(timeout=60000)
-    box = chart.bounding_box()
-    assert box is not None
-    assert box["width"] > 700
+    assert_chart_rendered(page)
 
     page.get_by_role("group", name="Click to view actions").get_by_role("img").click()
     with page.expect_download() as download_info:


### PR DESCRIPTION
The by_platform and by_standard_name e2e tests sampled canvas.bounding_box()
once, right after the chart became visible. Vega renders at a default width
then re-renders at the container width via a resize observer, detaching the
<canvas> in between, so bounding_box() transiently returns None on slower CI
runners (reproduced 4/6 under 20x CPU throttle). This is why the tests passed
in PRs but failed on the main merge build.

Add tests/e2e/helpers.py::assert_chart_rendered, which polls until the canvas
width settles and checks a 600px threshold (full-width ~750px vs the ~400px
narrow-chart regression); exclude it from the pytest-test-first hook. Use it in
all three chart tests.