### PR TITLE
Dump Github Actions events

### DIFF
--- a/.github/workflows/dump_event.yml
+++ b/.github/workflows/dump_event.yml
@@ -1,0 +1,55 @@
+name: "Dump GitHub Event"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dump_event:
+    runs-on: ubuntu-24.04
+    name: Dump Github event info for debugging
+    permissions:
+      contents: read
+    steps:
+      - name: Dump event
+        run: jq . "$GITHUB_EVENT_PATH"
+      - name: Upload event file
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-event
+          path: ${{ github.event_path }}
+      - name: Dump github context
+        env:
+          CONTEXT: ${{ toJSON(github) }}
+          CONTEXT_PATH: ${{ github.workspace }}/github-context.json
+        run: echo "$CONTEXT" | tee "$CONTEXT_PATH" | jq .
+      - name: Save github context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-context
+          path: ${{ github.workspace }}/github-context.json
+      - name: Environment variables
+        run: printenv
+      - name: PR merge JSON
+        if: github.event_name == 'push'
+        env:
+          REPO: ${{ github.repository }}
+          GIT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_MERGE_JSON: ${{ github.workspace }}/pr-merge.json
+        run: |
+          { gh api "repos/$REPO/commits/$GIT_SHA/pulls" --jq '.[0] // empty' || true; } | tee "$PR_MERGE_JSON"
+
+      - name: Upload PR merge JSON
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-merge
+          path: ${{ github.workspace }}/pr-merge.json


### PR DESCRIPTION
So that it’s easier to build tooling to more safely deploy to private github repos 

xref:https://github.com/ioos/buoy_retriever/issues/93#issuecomment-4916322751