### PR TITLE
ODP Releaser 5

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -186,25 +186,24 @@ jobs:
         run: |
           docker tag gmri/neracoos-climatology-py-dash:latest "gmri/neracoos-climatology-py-dash:$TAG"
           docker push "gmri/neracoos-climatology-py-dash:$TAG"
-          echo "image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' gmri/neracoos-climatology-py-dash:$TAG)" >> $GITHUB_OUTPUT
+          echo "image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' gmri/neracoos-climatology-py-dash:$TAG | cut -d@ -f2)" >> $GITHUB_OUTPUT
 
   notify:
     needs: [push]
     if: |
       github.repository == 'gulfofmaine/climatology_py_dash'
       && github.ref == 'refs/heads/main'
-    uses: gulfofmaine/odp-releaser/.github/workflows/notify.yml@cbad29f07eeb4c04c7594ea7c20c5791b5030524
+    uses: gulfofmaine/odp-releaser/.github/workflows/notify.yml@52b11709c1fb73c142b24b62ce7a11ecb37f7da3
     permissions:
       contents: read
       pull-requests: read # ODP Releaser wants to figure out who made a PR
     with:
-      image_name: climatology_py_dash
+      image_name: gmri/neracoos-climatology-py-dash
       tag: ${{ needs.push.outputs.tag }}
       digest: ${{ needs.push.outputs.image_digest }}
-      image_repository: gmri/neracoos-climatology-py-dash # optional
       environment: notify # optional gate
       # deploy_targets_path: .github/deploy_targets.yaml  # optional
-      # verbosity: 1                                       # optional, default
+      verbosity: 3 # optional, default
     secrets:
       dispatch_app_id: ${{ secrets.GULFOFMAINE_ODP_DISPATCH_APP_ID }}
       dispatch_app_private_key:


### PR DESCRIPTION
Simplify some notifications and make some errors happen at the notify step rather than pass bad data to bump_images.

xref https://github.com/gulfofmaine/odp-releaser/pull/14

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #103 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #102 
- <kbd>&nbsp;3&nbsp;</kbd> #101 
- <kbd>&nbsp;2&nbsp;</kbd> #100 
- <kbd>&nbsp;1&nbsp;</kbd> #99 
<!-- GitButler Footer Boundary Bottom -->

