### PR TITLE
Stabilize the chart PNG download in the e2e tests

### DIFF
--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -2,41 +2,89 @@
 
 import time
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Download, Locator, Page, expect
 
 # A full-width chart is ~750px on the 1280px test viewport; the narrow-chart
 # regression (Vega's default when width isn't set to "container") is ~400px.
 # 600 cleanly separates the two.
 MIN_CHART_WIDTH = 600
 
+# How many identical bounding boxes in a row mean the chart has stopped moving.
+# Two was not enough on CI: the canvas can report the same width twice while
+# still sliding down the page as the surrounding cell grows.
+SETTLED_SAMPLES = 3
+SAMPLE_INTERVAL_MS = 300
+SETTLE_TIMEOUT_S = 60
 
-def assert_chart_rendered(page: Page, *, min_width: int = MIN_CHART_WIDTH) -> None:
-    """Assert the first vega chart rendered without errors and fills its container.
+
+def wait_for_chart_settled(page: Page) -> Locator:
+    """Return the first vega chart canvas once its geometry has stopped changing.
 
     Vega renders once at a default width and then re-renders at the container
     width via a resize observer, detaching and replacing the ``<canvas>`` in the
     process. ``bounding_box()`` therefore transiently returns ``None`` (or a
-    pre-resize width) right after the canvas becomes visible, which is flaky on
-    slower CI runners. Poll until the width settles instead of sampling once.
-    """
-    expect(page.get_by_text("Duplicate signal name")).to_have_count(0)
+    pre-resize box) right after the canvas becomes visible, which is flaky on
+    slower CI runners.
 
+    Compare the *whole* box rather than just the width: a steady width tells us
+    nothing about position, and overlays anchored to the chart -- notably the
+    Vega actions menu -- keep moving while it settles, which is what defeats
+    Playwright's click stability check.
+    """
     chart = page.locator("canvas").first
     expect(chart).to_be_visible(timeout=60000)
 
-    deadline = time.monotonic() + 60
-    stable_width = None
-    last_width = None
+    deadline = time.monotonic() + SETTLE_TIMEOUT_S
+    last_box = None
+    repeats = 1
     while time.monotonic() < deadline:
         box = chart.bounding_box()
-        width = box["width"] if box else None
-        if width and width == last_width:
-            stable_width = width
-            break
-        last_width = width
-        page.wait_for_timeout(250)
+        if box is not None and box == last_box:
+            repeats += 1
+            if repeats >= SETTLED_SAMPLES:
+                return chart
+        else:
+            repeats = 1
+        last_box = box
+        page.wait_for_timeout(SAMPLE_INTERVAL_MS)
 
-    assert stable_width is not None, "chart canvas never reported a stable width"
-    assert stable_width > min_width, (
-        f"chart width {stable_width} <= {min_width}; expected a full-width chart"
+    msg = (
+        f"chart canvas never reported {SETTLED_SAMPLES} identical bounding boxes "
+        f"within {SETTLE_TIMEOUT_S}s (last box: {last_box})"
     )
+    raise AssertionError(msg)
+
+
+def assert_chart_rendered(page: Page, *, min_width: int = MIN_CHART_WIDTH) -> None:
+    """Assert the first vega chart rendered without errors and fills its container."""
+    expect(page.get_by_text("Duplicate signal name")).to_have_count(0)
+
+    chart = wait_for_chart_settled(page)
+
+    box = chart.bounding_box()
+    assert box is not None, "chart canvas reported no bounding box once settled"
+    assert box["width"] > min_width, (
+        f"chart width {box['width']} <= {min_width}; expected a full-width chart"
+    )
+
+
+def download_chart_png(page: Page) -> Download:
+    """Open the Vega actions menu and download the chart as a PNG.
+
+    The menu is anchored to the chart, so it keeps moving while Vega re-renders
+    and Playwright's stability check never settles -- the click then times out
+    after 30s. Wait for the chart to settle, assert the menu actually opened,
+    then click past the stability wait. ``expect_download`` still fails if no
+    download starts, so nothing is weakened by forcing the click.
+    """
+    wait_for_chart_settled(page)
+
+    page.get_by_role("group", name="Click to view actions").get_by_role("img").click()
+
+    save_as_png = page.get_by_role("link", name="Save as PNG")
+    expect(save_as_png).to_be_visible()
+
+    with page.expect_download() as download_info:
+        save_as_png.click(force=True)
+
+    return download_info.value

--- a/tests/e2e/test_by_platform.py
+++ b/tests/e2e/test_by_platform.py
@@ -1,4 +1,4 @@
-from helpers import assert_chart_rendered
+from helpers import assert_chart_rendered, download_chart_png
 from playwright.sync_api import Page, expect
 
 
@@ -14,12 +14,7 @@ def test_western_maine_shelf(page: Page) -> None:
 
     assert_chart_rendered(page)
 
-    page.locator("summary").click()
-
-    with page.expect_download() as download_info:
-        page.get_by_role("link", name="Save as PNG").click()
-    download = download_info.value
-    assert download.suggested_filename.endswith(".png")
+    assert download_chart_png(page).suggested_filename.endswith(".png")
 
     page.get_by_role("button", name="Full dataframe and download").click()
     page.get_by_role("button", name="Export").click()

--- a/tests/e2e/test_by_standard_name.py
+++ b/tests/e2e/test_by_standard_name.py
@@ -1,4 +1,4 @@
-from helpers import assert_chart_rendered
+from helpers import assert_chart_rendered, download_chart_png
 from playwright.sync_api import Page, expect
 
 
@@ -23,11 +23,7 @@ def test_air_temp(page: Page) -> None:
 
     assert_chart_rendered(page)
 
-    page.get_by_role("group", name="Click to view actions").get_by_role("img").click()
-    with page.expect_download() as download_info:
-        page.get_by_role("link", name="Save as PNG").click()
-    download = download_info.value
-    assert download.suggested_filename.endswith(".png")
+    assert download_chart_png(page).suggested_filename.endswith(".png")
 
     page.get_by_role("button", name="Full dataframe and download").click()
     page.get_by_role("button", name="Export").click()

--- a/tests/e2e/test_climatology.py
+++ b/tests/e2e/test_climatology.py
@@ -2,7 +2,7 @@
 End-to-end tests for the Climatology page of the application.
 """
 
-from helpers import assert_chart_rendered
+from helpers import assert_chart_rendered, download_chart_png
 from playwright.sync_api import Page, expect
 
 
@@ -18,8 +18,4 @@ def test_western_maine_shelf_air(page: Page) -> None:
 
     assert_chart_rendered(page)
 
-    page.get_by_role("group", name="Click to view actions").get_by_role("img").click()
-    with page.expect_download() as download_info:
-        page.get_by_role("link", name="Save as PNG").click()
-    download = download_info.value
-    assert download.suggested_filename.endswith(".png")
+    assert download_chart_png(page).suggested_filename.endswith(".png")


### PR DESCRIPTION
`test_air_temp[chromium]` is the single failure behind most of the current red CI — on `main` (run 514) and on the two Renovate PRs whose diffs let the suite actually run, #97 and #105. It is a race, not a regression: `main` alternates pass/fail across runs 486–514.

## What's happening

The Vega actions menu is anchored to the chart canvas, which marimo/Vega re-render on resize. The menu therefore keeps moving, Playwright's click stability check never settles, and the click times out after 30s in one of two ways:

```
# #97 / #105 — menu open, link never clickable
  - locator resolved to <a href="#" download="visualization.png">Save as PNG</a>
  - attempting click action
    2 × waiting for element to be visible, enabled and stable
      - element is not stable

# main run 514 — menu click itself landed mid-render
  - waiting for get_by_role("link", name="Save as PNG")
```

`assert_chart_rendered` was meant to absorb this but only compared canvas **width** across two samples 250 ms apart. Width says nothing about position — the chart can hold a steady width while still sliding down the page as the surrounding cell grows.

## Changes

- `wait_for_chart_settled` — split out of `assert_chart_rendered`; compares the whole bounding box and requires three identical samples before returning.
- `assert_chart_rendered` — unchanged signature and assertions, now built on the above.
- `download_chart_png` — settles the chart, opens the menu, asserts the link is visible, then clicks past the stability wait. `expect_download` still fails if no download starts, so forcing the click weakens nothing; and the explicit visibility assertion turns `main`'s symptom into a clear failure instead of an opaque click timeout.
- The three duplicated download blocks now call the helper, including `test_by_platform.py`'s divergent `page.locator("summary")` click.

## Verification

`ruff check` / `ruff format --check` pass. The suite itself needs the built container plus live ERDDAP access, so CI is the real check — please re-run the `End-to-end tests` job once or twice after it goes green, since a single green run does not disprove a race.

Does not touch #97 or #105 directly; they should go green once this is on `main` and they are rebased.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAo7VTsku1ned9LeQJ6JmK)_