### PR TITLE
Archive the full container log, filter the inline copy

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -121,7 +121,18 @@ jobs:
 
       - name: Show app container logs
         if: failure()
-        run: docker logs climatology
+        run: |
+          mkdir -p test-results
+          # The full log ships as an artifact; the inline copy drops the
+          # thousands of static-asset, service-worker and health 200s that
+          # otherwise bury the pytest traceback (~4100 lines -> ~120). Anything
+          # else -- 404s, redirects, warnings, tracebacks, websocket lifecycle
+          # -- is kept inline. grep exits 1 when it filters everything out, and
+          # this step runs under `bash -e`, hence the `|| true`.
+          docker logs climatology 2>&1 \
+            | tee test-results/container.log \
+            | grep -vE '"GET [^"]*/(assets/[^"]*|public-files-sw\.js(\?[^"]*)?|health)" 200 OK$' \
+            || true
 
       - name: Upload test results
         if: failure()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -125,13 +125,20 @@ jobs:
           mkdir -p test-results
           # The full log ships as an artifact; the inline copy drops the
           # thousands of static-asset, service-worker and health 200s that
-          # otherwise bury the pytest traceback (~4100 lines -> ~120). Anything
+          # otherwise bury the pytest traceback (~4100 lines -> ~100). Anything
           # else -- 404s, redirects, warnings, tracebacks, websocket lifecycle
-          # -- is kept inline. grep exits 1 when it filters everything out, and
-          # this step runs under `bash -e`, hence the `|| true`.
+          # -- is kept inline.
+          #
+          # The status tail differs by server, so match both: uvicorn ends the
+          # line with `200 OK`, granian with `200 <duration>`. The optional
+          # ` HTTP/x.y` is what closes out a path with no trailing wildcard of
+          # its own, such as /health.
+          #
+          # grep exits 1 when it filters everything out, and this step runs
+          # under `bash -e`, hence the `|| true`.
           docker logs climatology 2>&1 \
             | tee test-results/container.log \
-            | grep -vE '"GET [^"]*/(assets/[^"]*|public-files-sw\.js(\?[^"]*)?|health)" 200 OK$' \
+            | grep -vE '"GET [^"]*/(assets/[^"]*|public-files-sw\.js(\?[^"]*)?|health)( HTTP/[0-9.]+)?" 200 (OK|[0-9.]+)$' \
             || true
 
       - name: Upload test results


### PR DESCRIPTION
Diagnosing the current round of e2e failures meant downloading the raw 600 KB job log, because `Show app container logs` prints every marimo asset request — **4126 lines** on run 514 — and the pytest traceback is somewhere in the middle of it.

## Change

`tee` the container log to `test-results/container.log`, and filter only the inline copy:

```
docker logs climatology 2>&1 \
  | tee test-results/container.log \
  | grep -vE '"GET [^"]*/(assets/[^"]*|public-files-sw\.js(\?[^"]*)?|health)" 200 OK$' \
  || true
```

Nothing is lost — the full log is archived. `test-results/` is already the path of the existing `Upload test results` step, so `container.log` rides along in the `playwright-test-results` artifact with no second upload step.

## Verified on a real red run

This PR's own e2e run flaked on `test_air_temp` (the `Save as PNG` race that #110 fixes), which made it the ideal test case:

| | before (run 514) | after (this PR's run) |
|---|---|---|
| whole job log | 5000 lines | **1034 lines** |
| container log inline | 4126 lines | ~120 |
| artifact contents | 2 files | **3 files** (`container.log` added) |

The traceback is now visible without scrolling past asset noise, and every 404, redirect, warning and traceback survives the filter. The filtered output immediately surfaced something that had been buried — the sidebar logo 404ing on every page, now fixed in #112.

## Side effect worth having

That artifact is currently empty whenever the job dies before pytest produces output — as on #109 and #88, where `pixi install --locked` rejects the stale lock and the step logs `No files were found with the provided path: test-results/`. The container log now ships regardless, and `if-no-files-found: warn` stops firing.

## Note

`grep` exits 1 when it filters everything out and the step runs under `bash -e`, hence the `|| true`. Both the normal and filter-everything cases were tested to confirm the step exits 0.