### PR TITLE
Serve public/ with granian so the sidebar logo stops 404ing

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,10 +12,10 @@ server = (
 
 app = FastAPI()
 
+# public/ is served by granian, ahead of this app -- see the `serve` task in
+# pyproject.toml. marimo's own public-file convention (a relative
+# <img src="public/..."> resolved against a public/ directory beside the
+# notebook) does not reach those files once the notebooks are composed with
+# create_asgi_app(), so without that static route the sidebar logo 404s on
+# every page.
 app.mount("/", server.build())
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run(app, host="0.0.0.0", port=8080)  # nosec B104

--- a/common.py
+++ b/common.py
@@ -114,7 +114,7 @@ def sidebar_menu():
         [
             mo.Html("""
             <a href="https://neracoos.org">
-    <img src="public/neracoos.png" />
+    <img src="/public/neracoos.png" />
     </a>
     """),
             mo.nav_menu(

--- a/pixi.lock
+++ b/pixi.lock
@@ -54,6 +54,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/granian-2.7.9-py314h1bee95f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py314h5bd0f2a_1.conda
@@ -95,6 +96,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjemalloc-5.3.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-28_h7ac8fdf_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
@@ -385,6 +387,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/granian-2.7.9-py314he1d1ac0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.8.0-py314h6c2aa35_0.conda
@@ -424,6 +427,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjemalloc-5.3.0-hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-28_hc9a63f6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
@@ -537,6 +541,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/granian-2.7.9-py314h1bee95f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.3-py314h42812f9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
@@ -579,6 +584,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjemalloc-5.3.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
@@ -884,6 +890,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/granian-2.7.9-py314he1d1ac0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.3-py314he609de1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
@@ -924,6 +931,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjemalloc-5.3.0-hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
@@ -1611,6 +1619,31 @@ packages:
     - glog >=0.7.1,<0.8.0a0
   size: 143452
   timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/granian-2.7.9-py314h1bee95f_0.conda
+  sha256: b5b104ccbc8fcd6d4108dd74346e6f064f37965a3dcd6654fe551be87bd173b4
+  md5: fdded9c1f45d0bd2a972b64674a034e6
+  depends:
+  - click >=8.1.0
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libjemalloc >=5.3.0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - python-dotenv >=1.1,<2
+  - rloop >=0.1,<1.0
+  - setproctitle >=1.3.3,<1.4
+  - uvloop >=0.18.0
+  - watchfiles >=1.0,<2.0
+  - winloop >=0.2.2
+  - __glibc >=2.17
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/granian?source=hash-mapping
+  run_exports: {}
+  size: 3962425
+  timestamp: 1783099902872
 - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
   sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
   md5: cf09e9fc938518e91d0706572cadf17a
@@ -2465,6 +2498,21 @@ packages:
   purls: []
   size: 713084
   timestamp: 1740128065462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjemalloc-5.3.0-h5888daf_1.conda
+  sha256: 4b43f86519a9a31aaa2473fe8373cf313713ce83e349991b4faa0c0995e8b0bb
+  md5: 29f738fc41e063bfb120b1a667f684dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libjemalloc >=5.3.0
+  size: 1571937
+  timestamp: 1726817494251
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
   sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
   md5: 8397539e3a0bbd1695584fb4f927485a
@@ -3215,7 +3263,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.25,<3
@@ -3343,7 +3391,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 15303815
   timestamp: 1778602611222
@@ -3641,7 +3689,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 309696
   timestamp: 1779976994059
@@ -4157,7 +4205,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/anyio?source=compressed-mapping
+  - pkg:pypi/anyio?source=hash-mapping
   run_exports: {}
   size: 161308
   timestamp: 1782357087265
@@ -4291,7 +4339,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click?source=compressed-mapping
+  - pkg:pypi/click?source=hash-mapping
   run_exports: {}
   size: 104999
   timestamp: 1779900548735
@@ -4495,8 +4543,7 @@ packages:
   - uvicorn-standard
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/fastapi?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 4836
   timestamp: 1782997724066
@@ -4529,7 +4576,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fastapi-cli?source=compressed-mapping
+  - pkg:pypi/fastapi-cli?source=hash-mapping
   run_exports: {}
   size: 19304
   timestamp: 1781833514276
@@ -4830,7 +4877,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/importlib-metadata?source=compressed-mapping
+  - pkg:pypi/importlib-metadata?source=hash-mapping
   run_exports: {}
   size: 34766
   timestamp: 1779714582554
@@ -5433,7 +5480,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/python-multipart?source=compressed-mapping
+  - pkg:pypi/python-multipart?source=hash-mapping
   run_exports: {}
   size: 38132
   timestamp: 1780610429919
@@ -5591,7 +5638,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rich-toolkit?source=compressed-mapping
+  - pkg:pypi/rich-toolkit?source=hash-mapping
   run_exports: {}
   size: 34331
   timestamp: 1780659356824
@@ -5691,7 +5738,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/starlette?source=compressed-mapping
+  - pkg:pypi/starlette?source=hash-mapping
   run_exports: {}
   size: 64264
   timestamp: 1781447071524
@@ -5793,7 +5840,7 @@ packages:
   - python
   license: MIT AND BSD-3-Clause
   purls:
-  - pkg:pypi/typer?source=compressed-mapping
+  - pkg:pypi/typer?source=hash-mapping
   run_exports: {}
   size: 186572
   timestamp: 1782477870892
@@ -5924,7 +5971,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/uvicorn?source=compressed-mapping
+  - pkg:pypi/uvicorn?source=hash-mapping
   run_exports: {}
   size: 56228
   timestamp: 1780574319325
@@ -6559,6 +6606,30 @@ packages:
     - glog >=0.7.1,<0.8.0a0
   size: 112215
   timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/granian-2.7.9-py314he1d1ac0_0.conda
+  sha256: 3c0139aa77da70ae7e3b04302cc76de0a5620c3e331b5c04c70223b7b9f4c5d2
+  md5: e17adb985976d2188d4001cfe89270e3
+  depends:
+  - click >=8.1.0
+  - python
+  - __osx >=11.0
+  - libjemalloc >=5.3.0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - python-dotenv >=1.1,<2
+  - rloop >=0.1,<1.0
+  - setproctitle >=1.3.3,<1.4
+  - uvloop >=0.18.0
+  - watchfiles >=1.0,<2.0
+  - winloop >=0.2.2
+  - __osx >=11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/granian?source=hash-mapping
+  run_exports: {}
+  size: 3526365
+  timestamp: 1783099876568
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
   sha256: c0a060d7b7a05669043ef3f68c7a1025c8594e1ab73735afb64c35e8baa41da5
   md5: 0d576cff278a2e60456d5b2c0a1ffda3
@@ -7274,6 +7345,20 @@ packages:
     - libintl >=0.25.1,<1.0a0
   size: 90957
   timestamp: 1751558394144
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjemalloc-5.3.0-hf9b8971_1.conda
+  sha256: 36e13aca6da28342249ab0ba761fb30a2c0824005334b7d047217515fa468650
+  md5: 09f1ec790b5f7b010a2a38d1f349df01
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libjemalloc >=5.3.0
+  size: 222984
+  timestamp: 1726817626329
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
   sha256: 17e035ae6a520ff6a6bb5dd93a4a7c3895891f4f9743bcb8c6ef607445a31cd0
   md5: b8a7544c83a67258b0e8592ec6a5d322
@@ -8091,7 +8176,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 14368928
   timestamp: 1778602917992

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,22 @@ cmd = "playwright show-trace {{trace_path}}"
 edit = "marimo edit"
 app = "marimo run climatology.py"
 # serve = "marimo run climatology.py --host 0.0.0.0 -p 8080 --base-url /climatology"
+
 # granian serves public/ itself, so requests for the logo never reach the app.
 # The route is absolute (/public) so it resolves identically from every
 # sub-mounted marimo app; see common.py's sidebar_menu().
-serve = "granian --interface asgi --host 0.0.0.0 --port 8080 --static-path-route /public --static-path-mount public app:app"
+#
+# host and port are arguments so the e2e suite can bind a free port on
+# localhost without restating the static options -- see tests/e2e/conftest.py.
+[tool.pixi.tasks.serve]
+args = [
+  { arg = "host", default = "0.0.0.0" },
+  { arg = "port", default = "8080" },
+]
+cmd = """\
+  granian --interface asgi --host {{ host }} --port {{ port }} --static-path-route /public --static-path-mount public \
+  app:app\
+  """
 
 [tool.pixi.workspace]
 channels = [ "conda-forge" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ vegafusion-python-embed = ">=1.6.9,<2"
 vl-convert-python = ">=1.7.0,<2"
 pyarrow = ">=24,<25"
 fastapi = ">=0.139,<0.140"
-uvicorn = ">=0.49,<0.50"
+granian = ">=2.7,<3"
 matplotlib-base = ">=3.10.8,<4"
 scipy = ">=1.15.2,<2"
 requests = ">=2.32.5,<3"
@@ -63,7 +63,10 @@ cmd = "playwright show-trace {{trace_path}}"
 edit = "marimo edit"
 app = "marimo run climatology.py"
 # serve = "marimo run climatology.py --host 0.0.0.0 -p 8080 --base-url /climatology"
-serve = "python app.py"
+# granian serves public/ itself, so requests for the logo never reach the app.
+# The route is absolute (/public) so it resolves identically from every
+# sub-mounted marimo app; see common.py's sidebar_menu().
+serve = "granian --interface asgi --host 0.0.0.0 --port 8080 --static-path-route /public --static-path-mount public app:app"
 
 [tool.pixi.workspace]
 channels = [ "conda-forge" ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,6 +5,11 @@ starts the FastAPI/marimo app (``app:app``) in a subprocess on a free port and
 tears it down afterwards. If the ``E2E_BASE_URL`` environment variable is set,
 that URL is used as-is and no server is spawned -- handy for pointing the suite
 at an already-running server or Docker container (e.g. in CI).
+
+The subprocess is granian with the same static-file arguments as the ``serve``
+task in pyproject.toml, so a local run serves ``public/`` exactly like the
+container does. Without them the sidebar logo 404s and only the local run would
+notice.
 """
 
 import os
@@ -57,7 +62,7 @@ def _wait_until_ready(url: str, timeout: float = 60.0) -> None:
 def app_server() -> str:
     """Yield the base URL of the running app.
 
-    Uses ``E2E_BASE_URL`` if set (no server spawned); otherwise starts uvicorn
+    Uses ``E2E_BASE_URL`` if set (no server spawned); otherwise starts granian
     in its own process group and cleans it up on teardown.
     """
     external_url = os.environ.get("E2E_BASE_URL")
@@ -72,12 +77,18 @@ def app_server() -> str:
         [
             sys.executable,
             "-m",
-            "uvicorn",
-            "app:app",
+            "granian",
+            "--interface",
+            "asgi",
             "--host",
             "127.0.0.1",
             "--port",
             str(port),
+            "--static-path-route",
+            "/public",
+            "--static-path-mount",
+            "public",
+            "app:app",
         ],
         cwd=str(REPO_ROOT),
         # New session/process group so the whole tree can be signalled together.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,17 +6,16 @@ tears it down afterwards. If the ``E2E_BASE_URL`` environment variable is set,
 that URL is used as-is and no server is spawned -- handy for pointing the suite
 at an already-running server or Docker container (e.g. in CI).
 
-The subprocess is granian with the same static-file arguments as the ``serve``
-task in pyproject.toml, so a local run serves ``public/`` exactly like the
-container does. Without them the sidebar logo 404s and only the local run would
-notice.
+The subprocess runs the ``serve`` task from pyproject.toml, overriding only its
+host and port arguments, so a local run serves ``public/`` through granian
+exactly like the container does. Restating granian's static options here instead
+would let the two drift, and the sidebar logo would 404 in only one of them.
 """
 
 import os
 import signal
 import socket
 import subprocess
-import sys
 import time
 import urllib.error
 import urllib.request
@@ -74,22 +73,7 @@ def app_server() -> str:
     base_url = f"http://127.0.0.1:{port}"
 
     process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "granian",
-            "--interface",
-            "asgi",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--static-path-route",
-            "/public",
-            "--static-path-mount",
-            "public",
-            "app:app",
-        ],
+        ["pixi", "run", "serve", "127.0.0.1", str(port)],
         cwd=str(REPO_ROOT),
         # New session/process group so the whole tree can be signalled together.
         start_new_session=True,

--- a/tests/e2e/test_pages.py
+++ b/tests/e2e/test_pages.py
@@ -60,6 +60,25 @@ def test_sidebar_navigates_to_by_platform(page: Page) -> None:
     expect(page).to_have_url(re.compile(r"/by_platform/?"), timeout=RENDER_TIMEOUT)
 
 
+@pytest.mark.parametrize("route", [route for route, _ in PAGES])
+def test_sidebar_logo_renders(page: Page, route: str) -> None:
+    """The sidebar logo actually loads, on every mounted app.
+
+    The src is absolute so that it resolves the same from the sub-mounted pages;
+    a relative "public/neracoos.png" asks for "/by_platform/public/..." and 404s.
+    """
+    page.goto(route)
+
+    logo = page.locator('img[src="/public/neracoos.png"]').first
+    # Once `complete` is true the browser has finished with the image, whether it
+    # decoded or errored, so naturalWidth has settled. A 404 leaves the <img>
+    # element in place with naturalWidth 0.
+    expect(logo).to_have_js_property("complete", True, timeout=RENDER_TIMEOUT)
+    assert logo.evaluate("img => img.naturalWidth") > 0, (
+        f"sidebar logo did not load on {route}"
+    )
+
+
 @pytest.fixture
 def api_request_context(
     playwright: Playwright,
@@ -79,3 +98,14 @@ def test_health_endpoint_returns_200(api_request_context: APIRequestContext) -> 
     """The /health endpoint used by the Docker HEALTHCHECK returns 200."""
     response = api_request_context.get("/health")
     assert response.status == 200
+
+
+def test_public_logo_is_served(api_request_context: APIRequestContext) -> None:
+    """public/ is mounted, so the logo is fetchable as an image.
+
+    Checking the content type too, so that the catch-all marimo mount answering
+    with an HTML page cannot pass this.
+    """
+    response = api_request_context.get("/public/neracoos.png")
+    assert response.status == 200
+    assert response.headers["content-type"].startswith("image/")


### PR DESCRIPTION
The sidebar logo is a broken image on **every page**. Spotted in the container log while reducing its noise (#111):

```
GET /public/neracoos.png              404 Not Found
GET /by_platform/public/neracoos.png  404 Not Found
```

## Why

`common.py` used marimo's documented public-file convention — a relative ``'&lt;img src="public/neracoos.png"&gt;'`` next to a `public/` directory — but nothing serves that path once the notebooks are composed with `create_asgi_app()`. Because the src was relative, it also asked for a different URL from each mounted app, hence both 404s.

`neracoos_logo()` (`common.py:66`) was never affected — it reads the PNG off disk and inlines it as a base64 data URI into the Altair chart. That is why the in-chart logo looks right and this went unnoticed.

## Changes

Rather than mounting `StaticFiles` inside the app, switch the server from uvicorn to **granian** and let it serve `public/` itself, so those requests never reach Python:

```
serve = "granian --interface asgi --host 0.0.0.0 --port 8080 --static-path-route /public --static-path-mount public app:app"
```

- `pyproject.toml` — `granian` replaces `uvicorn` as the direct dependency, and the `serve` task carries the static route. The Dockerfile already runs `pixi run --frozen serve`, so it picks this up unchanged.
- `app.py` — no static mount and no `uvicorn.run` `__main__` block; the `serve` task is the single entry point. The file is now just the marimo composition plus `app = FastAPI()`.
- `common.py` — absolute `/public/neracoos.png`, so it resolves identically from the sub-mounted apps.
- `tests/e2e/conftest.py` — the local (non-CI) fixture spawns granian with the same static arguments, so a local run serves `public/` exactly like the container. Without that the new assertions would only hold in CI.
- `tests/e2e/test_pages.py` — coverage this never had: an API check that the route answers with an `image/*` content type (so the marimo catch-all replying with HTML cannot pass), and a per-page DOM check that the `<img>` actually decoded (`naturalWidth > 0`, since a 404 leaves the element at 0).

`granian` is pinned `>=2.7,<3` rather than `>=2.8` because `exclude-newer = "7d"` currently excludes 2.8.0; the `--static-path-*` options exist in both. `uvicorn` stays in the lock as marimo's transitive dependency.

## Verification

CI is green here: build, all e2e tests, and the pass gate — so marimo works over granian in the real app, WebSockets and chart downloads included, and the new logo assertions pass against granian's static route.

Checked granian's route→mount mapping directly before adopting it, with a stand-in ASGI app for marimo:

```
GET /public/neracoos.png ->  200 image/png 144580 bytes   (prefix stripped)
GET /                    ->  200 text/html               (app catch-all intact)
GET /by_platform/        ->  200                         (app catch-all intact)
GET /public/nope.png     ->  404
cache-control: max-age=86400                             (--static-path-expires default)
```

And confirmed the bug was real on all five routes beforehand — the pre-fix run reported `naturalWidth=0` on every page, with the API returning 404 `application/json`.

`ruff`, `pyproject-fmt` and `validate-pyproject` are clean. The `pixi.lock` here was regenerated by the `Relock` workflow from #113 (dispatched against this branch), which also served as a live test of it outside a Renovate branch.