### PR TITLE
Relock pixi.lock on Renovate branches

### DIFF
--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -1,0 +1,81 @@
+name: "Relock"
+
+# Renovate updates the dependency specs in pyproject.toml but leaves pixi.lock
+# alone, so `pixi install --locked` rejects the workspace and every job that
+# needs the test environment dies before it runs. Regenerate the lock on the
+# Renovate branch instead.
+#
+# Only bumps that move outside the already-locked version break: a spec change
+# the locked version still satisfies is fine, which is why some Renovate PRs
+# are green and others fail in ten seconds.
+
+on:
+  push:
+    branches: ["renovate/**"]
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 3
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  relock:
+    name: Regenerate pixi.lock
+    if: github.repository == 'gulfofmaine/climatology_py_dash'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write # push the refreshed lock back to the Renovate branch
+      actions: write # re-dispatch Push; see the last step
+
+    steps:
+      # Unlike the other workflows this one has to push, so it keeps the
+      # credentials that `persist-credentials: false` would discard.
+      - name: "Checkout"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          # The default `pixi install --locked` is exactly what a stale lock
+          # breaks, so do not let the action attempt it before we relock.
+          run-install: false
+
+      - name: Regenerate the lock file
+        run: pixi lock
+
+      - name: Commit and push the refreshed lock
+        id: commit
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet -- pixi.lock; then
+            echo "pixi.lock already satisfies pyproject.toml; nothing to do."
+            echo "relocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pixi.lock
+          git commit -m "Regenerate pixi.lock for the updated dependency specs"
+          git push origin "HEAD:$BRANCH"
+          echo "relocked=true" >> "$GITHUB_OUTPUT"
+
+      # A push made with GITHUB_TOKEN does not trigger `on: push`, which is both
+      # why this workflow cannot loop on its own commit and why Push has to be
+      # asked for explicitly -- otherwise the PR head would move to a commit
+      # carrying no checks at all, which is worse than a red one.
+      - name: Re-run Push against the relocked commit
+        if: steps.commit.outputs.relocked == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.ref_name }}
+        run:
+          gh workflow run push.yml --ref "$BRANCH" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Renovate rewrites the dependency spec in `pyproject.toml` and leaves `pixi.lock` alone. `setup-pixi` then runs `pixi install --locked`, which rejects the workspace and kills the e2e job ten seconds in, before any test runs:

```
Error: × lock file not up-to-date with the workspace
```

## Why it looks intermittent

Only bumps that move *outside* the already-locked version break:

| PR | spec change | locked | satisfies? |
|----|-------------|--------|-----------|
| #109 | `fastapi >=0.139,<0.140` → `>=0.140,<0.141` | `0.139.0` | no → fails in 10s |
| #88 | `playwright >=1.49,<1.61` → `>=1.62,<1.63` | `1.60.0` | no → fails in 10s |
| #97 | `numpy <2.5.1` → `<2.5.2` | `2.5.0` | yes → suite runs |

## The workflow

On push to `renovate/**`: regenerate the lock, commit it back to the branch, then ask `Push` to run against the new commit.

That last step is **not optional**. A push made with `GITHUB_TOKEN` does not trigger `on: push`, so without the explicit dispatch the PR head would move to a commit carrying *no checks at all* — worse than a red one. The same mechanic is why this cannot loop on its own commit, so no `github.actor` guard is needed (which also keeps zizmor's `bot-conditions` audit out of the picture).

Other details:

- `setup-pixi` runs with `run-install: false`, since its default `pixi install --locked` is precisely what a stale lock breaks.
- `contents: write` to push, `actions: write` to dispatch, both scoped to this one job.
- This is the only workflow here that keeps checkout credentials instead of `persist-credentials: false`, because it has to push. Worth knowing: `artipacked` does flag that at zizmor's `auditor` persona (Low confidence) but not at the `pedantic` persona this repo runs, so no inline ignore is needed.
- If `pixi lock` cannot resolve a bump — note `exclude-newer = "7d"` in `[tool.pixi.workspace]` and the existing comment about it splitting the playwright driver/library pair — the job fails loudly on that branch, which is the signal you want instead of a silently stale lock.

## Verification

Validated locally against the repo's own hooks: `zizmor --offline --persona=pedantic` reports no findings across all three workflows, `check-jsonschema --builtin-schema vendor.github-workflows` passes, and `prettier --prose-wrap=always --check` is clean.

The workflow itself cannot run until it is on `main`. After merge, trigger it via `workflow_dispatch` against `renovate/fastapi-0.x`: expect a lock commit moving `fastapi-0.139.0` → `0.140.x`, a dispatched `Push` run on that ref, and #109 going green. Then repeat for `renovate/playwright-monorepo` (#88).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAo7VTsku1ned9LeQJ6JmK)_