### PR TITLE
Keep the playwright driver and bindings on the same version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,14 @@ test = { features = [ "test" ], solve-group = "default" }
 [tool.pixi.feature.test.dependencies]
 pytest = ">=9"
 pytest-playwright = ">=0.7,<1"
-# driver must match playwright-python; exclude-newer can split the pair
+# conda-forge splits playwright into the node driver (playwright) and the Python
+# bindings (playwright-python), and they must move together. Constraining only
+# the driver let exclude-newer pull bindings 1.61 against driver 1.60 during
+# lock-file maintenance, which fails every browser assertion instantly with an
+# empty message. Keep both bounds identical, and see renovate.json for the
+# grouping that stops them being bumped apart.
 playwright = ">=1.49,<1.61"
+playwright-python = ">=1.49,<1.61"
 
 [tool.pixi.feature.test.tasks]
 e2e = "pytest tests/e2e --browser chromium --screenshot only-on-failure --tracing retain-on-failure"

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,12 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "The node driver and the Python bindings must stay on the same version; a split pair fails every browser assertion",
+      "matchPackageNames": ["playwright", "playwright-python"],
+      "groupName": "playwright driver and bindings"
+    }
+  ]
 }


### PR DESCRIPTION
This is the root cause of #93's mass failure, and it is **not** the app — the existing `# driver must match playwright-python` comment turned out to be describing the exact bug that then happened.

## What #93 actually did

conda-forge splits playwright into the node driver (`playwright`) and the Python bindings (`playwright-python`). Only the driver was constrained, so lock-file maintenance was free to move the bindings alone:

```
playwright         1.60.0 -> 1.60.0     (driver, capped by <1.61)
playwright-python  1.60.0 -> 1.61.0     (bindings, unconstrained)
```

A split pair does not fail loudly. The driver starts, the browser launches, navigation works — and then every assertion fails instantly with an **empty message**:

```
E           AssertionError: LocatorAssertions.to_be_visible:
```

That explains what looked inexplicable about #93's run: `9 failed, 1 passed in 25.03s`, even though four of those tests pass `timeout=RENDER_TIMEOUT` (60 s). They never waited — each failed in ~2 s. And the one test that passed was `test_health_endpoint_returns_200`, the only one that does not drive a browser.

## Evidence

Installed #93's lock and served the app locally — every page renders correctly, so the app was never at fault. Then A/B'd the two test environments against **the same running app and the same browser binary**, with an identical script:

| test env | binding | driver | result |
|---|---|---|---|
| #93's lock | **1.61.0** | 1.60.0 | `AssertionError: 'LocatorAssertions.to_be_visible: '` in ~2 s |
| `main`'s lock | 1.60.0 | 1.60.0 | **pass** |

Also confirmed it still reproduces today, not just on Jul 21: pushing #93's lock onto current `main` failed e2e in 25 s, the same signature.

## Fix

- `pyproject.toml` — constrain `playwright-python` to the same window as `playwright`, and replace the warning comment with what actually goes wrong.
- `renovate.json` — group the two packages so Renovate proposes them together and cannot bump them apart again.

## Verification

Both packages are already locked at 1.60.0, so this is **lock-neutral**: `pixi install --locked -e test` still accepts the existing `pixi.lock`, and `git status` shows no lock change. Verified locally with pixi 0.76.0, the same version CI uses. `pyproject-fmt` makes no changes, `validate-pyproject --disable-plugins pixi` passes, and `prettier --check` is clean on `renovate.json`.

## Knock-on for the open Renovate PRs

- **#93** can be closed and re-run; with the pair grouped, the next lock-file-maintenance PR will move both together. It cannot be merged as-is.
- **#88** is now incomplete as written: it moves `playwright` to `>=1.62,<1.63` and needs the same bound on `playwright-python`, or it will reintroduce the split from the other direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAo7VTsku1ned9LeQJ6JmK)_