### PR TITLE
Let approval start the relocked PR's checks instead of a dispatch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,14 @@
 name: "Push"
 
+# `pull_request` rather than `push` for branch builds, so the checks belong to
+# the pull request. That is what lets a Renovate PR whose lock was refreshed by
+# Relock pick these jobs up: a GITHUB_TOKEN push creates no `push` run at all,
+# but it does park the PR's `pull_request` runs at "awaiting approval", and one
+# approval then runs them and shows them in the PR's checks.
 on:
   push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -31,7 +31,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write # push the refreshed lock back to the Renovate branch
-      actions: write # re-dispatch Push; see the last step
 
     steps:
       # Unlike the other workflows this one has to push, so it keeps the
@@ -51,14 +50,20 @@ jobs:
       - name: Regenerate the lock file
         run: pixi lock
 
+      # Pushing with GITHUB_TOKEN does not trigger `on: push`, so this cannot
+      # loop on its own commit. It does mark the pull request as bot-updated,
+      # which parks that PR's `pull_request` runs at "awaiting approval" -- one
+      # "Approve and run" then starts them and they land in the PR's checks.
+      # That is why Push is not re-dispatched from here: a dispatched run is
+      # attributed to this workflow rather than the pull request, and it also
+      # cancels the still-running Push for the pre-relock commit through the
+      # shared concurrency group.
       - name: Commit and push the refreshed lock
-        id: commit
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
           if git diff --quiet -- pixi.lock; then
             echo "pixi.lock already satisfies pyproject.toml; nothing to do."
-            echo "relocked=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -66,16 +71,3 @@ jobs:
           git add pixi.lock
           git commit -m "Regenerate pixi.lock for the updated dependency specs"
           git push origin "HEAD:$BRANCH"
-          echo "relocked=true" >> "$GITHUB_OUTPUT"
-
-      # A push made with GITHUB_TOKEN does not trigger `on: push`, which is both
-      # why this workflow cannot loop on its own commit and why Push has to be
-      # asked for explicitly -- otherwise the PR head would move to a commit
-      # carrying no checks at all, which is worse than a red one.
-      - name: Re-run Push against the relocked commit
-        if: steps.commit.outputs.relocked == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BRANCH: ${{ github.ref_name }}
-        run:
-          gh workflow run push.yml --ref "$BRANCH" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Keeps Relock's auto-push, drops the follow-up dispatch, and lets the **approval** start the checks so they appear in the pull request's own check list.

## Why the dispatch existed, and why it can go

Relock pushes with `GITHUB_TOKEN`, which marks the PR as bot-updated. Per [this June 2026 change](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/), that no longer skips the PR's workflows — it parks its **`pull_request`** runs at *awaiting approval*, and one "Approve and run" starts them. Observed directly on this repo after Relock pushed:

```
pre-commit  ev=pull_request  sha=2e2acd37  conclusion=action_required   ← the approval prompt
```

`Push` could not take part in that, because it only triggered on `push` — and a `GITHUB_TOKEN` push creates no `push` run at all. Same run list, same commit:

```
Push  ev=workflow_dispatch  sha=2e2acd37  ← only because Relock asked for it
(no Push ev=push run for that commit exists)
```

So build and e2e had nothing for an approval to start. The `gh workflow run` step filled that gap, at the cost of two oddities: the run was attributed to Relock rather than to the pull request, and it cancelled the still-running `Push` for the pre-relock commit through the shared concurrency group (visible as `Push ev=push … conclusion=cancelled` on #88).

## Changes

- `push.yml` — trigger on `pull_request` for branch builds, and keep `push` for `main` only. The relock commit now parks `Push` alongside `pre-commit`, and one approval runs both into the PR's checks.
- `relock.yml` — the dispatch step and its `actions: write` permission are gone; it only ever pushes now.

## Trade-off to be aware of

Branches with no pull request open no longer get build/e2e on push. `main` still builds and pushes the image on merge, and `workflow_dispatch` still works. The `push` and `notify` jobs stay gated on `refs/heads/main` — which a `pull_request` run is not — so they continue to skip on PRs, as before.

## Verification

This PR exercises its own change: pushing the branch produced no `push` run, and the checks below come from the `pull_request` event.

The approval half rests on the `action_required` behaviour quoted above, which was observed on this repo rather than assumed — `push.yml` now sits on the same event that produced it. What it does not yet prove is the wording of a single approval covering both workflows at once; the next Renovate PR that needs a relock will show that, and #88 is due one since its `playwright` bump still needs #114.

`zizmor --persona=pedantic`, `check-jsonschema` and `prettier --check` are clean across all three workflows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAo7VTsku1ned9LeQJ6JmK)_