### PR TITLE
Add VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/base:noble
+
+# mise is not baked into the base image; it provisions pixi and prek at
+# postCreate time from the repo-root mise.toml.
+RUN curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+# Activate mise for the vscode user's interactive shells so pixi/prek are
+# on PATH once postCreateCommand has installed them.
+RUN echo 'eval "$(/usr/local/bin/mise activate bash)"' >> /home/vscode/.bashrc \
+  && echo 'eval "$(/usr/local/bin/mise activate zsh)"' >> /home/vscode/.zshrc
+
+ENV MARIMO_SKIP_UPDATE_CHECK=1

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "NERACOOS Climatology",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // linux/amd64 is forced because conda-forge does not publish recent
+    // linux-aarch64 builds of marimo; the repo's docker-compose.yml does
+    // the same for the production image.
+    "options": ["--platform=linux/amd64"]
+  },
+  "remoteUser": "vscode",
+  // Chromium (used by the Playwright e2e suite) crashes under Docker's
+  // default 64MB /dev/shm; give it real shared memory.
+  "runArgs": ["--shm-size=2gb"],
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+  },
+  "mounts": [
+    // Shadows the host's macOS .pixi env (incompatible with the Linux
+    // container) with a named volume that persists across rebuilds.
+    "source=climatology-pixi-env,target=${containerWorkspaceFolder}/.pixi,type=volume",
+    "source=climatology-rattler-cache,target=/home/vscode/.cache/rattler,type=volume",
+    "source=climatology-playwright-cache,target=/home/vscode/.cache/ms-playwright,type=volume",
+    "source=claude-code-config,target=/home/vscode/.claude,type=volume"
+  ],
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "climatology app"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "marimo-team.vscode-marimo",
+        "renan-r-santos.pixi-code",
+        "tamasfe.even-better-toml",
+        "hverlin.mise-vscode",
+        "ms-playwright.playwright"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Named volumes mount root-owned (as does ~/.cache, created as their parent
+# mountpoint); reclaim them for the vscode user.
+sudo chown -R vscode:vscode "$PWD/.pixi" /home/vscode/.cache
+
+# The bind-mounted workspace is owned by the host user, which git treats as
+# untrusted ownership inside the container.
+git config --global --add safe.directory "$PWD"
+
+/usr/local/bin/mise trust
+/usr/local/bin/mise install
+
+# Put the mise-managed pixi/prek shims on PATH for the rest of this script.
+eval "$(/usr/local/bin/mise activate bash --shims)"
+
+pixi install --frozen -e default -e test
+pixi run --frozen -e test playwright install --with-deps chromium
+prek install

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+# Keep the pixi version here in lockstep with the pinned
+# ghcr.io/prefix-dev/pixi:<version>-noble tag in the prod Dockerfile.
+[tools]
+pixi = "0.72.0"
+prek = "0.4.9"


### PR DESCRIPTION
Provisions pixi/prek via mise, mirrors CI's Playwright e2e setup
(chromium + --with-deps), and forwards port 8080 for the marimo/FastAPI
app. Forces linux/amd64 since conda-forge lacks recent linux-aarch64
marimo builds. Verified locally: image builds, postCreateCommand runs
cleanly, app starts and passes /health, and the full e2e suite passes
on native amd64 (QEMU-emulated amd64 on Apple Silicon hosts hits an
unrelated Chromium/QEMU signal-handling crash, not a devcontainer bug).