### PR TITLE
Serve the logo from /static, and turn granian's access log on

### DIFF
--- a/common.py
+++ b/common.py
@@ -114,7 +114,7 @@ def sidebar_menu():
         [
             mo.Html("""
             <a href="https://neracoos.org">
-    <img src="/public/neracoos.png" />
+    <img src="/static/neracoos.png" />
     </a>
     """),
             mo.nav_menu(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,19 +65,29 @@ app = "marimo run climatology.py"
 # serve = "marimo run climatology.py --host 0.0.0.0 -p 8080 --base-url /climatology"
 
 # granian serves public/ itself, so requests for the logo never reach the app.
-# The route is absolute (/public) so it resolves identically from every
-# sub-mounted marimo app; see common.py's sidebar_menu().
+# The route is absolute so it resolves identically from every sub-mounted
+# marimo app; see common.py's sidebar_menu().
+#
+# The route is /static rather than /public even though the directory is
+# public/: granian matches the route as a plain string prefix, not on path
+# segments, so /public would also swallow marimo's own /public-files-sw.js
+# (and anything else starting with those characters) and 404 it.
 #
 # host and port are arguments so the e2e suite can bind a free port on
 # localhost without restating the static options -- see tests/e2e/conftest.py.
+#
+# granian disables the access log by default, unlike uvicorn. Keep it on: the
+# container log is the only view of what the app was asked for when an e2e run
+# fails. Note it still records nothing for /public, which granian answers
+# without entering the app -- tests/e2e/test_pages.py covers those instead.
 [tool.pixi.tasks.serve]
 args = [
   { arg = "host", default = "0.0.0.0" },
   { arg = "port", default = "8080" },
 ]
 cmd = """\
-  granian --interface asgi --host {{ host }} --port {{ port }} --static-path-route /public --static-path-mount public \
-  app:app\
+  granian --interface asgi --host {{ host }} --port {{ port }} --access-log --static-path-route /static \
+  --static-path-mount public app:app\
   """
 
 [tool.pixi.workspace]

--- a/tests/e2e/test_pages.py
+++ b/tests/e2e/test_pages.py
@@ -69,7 +69,7 @@ def test_sidebar_logo_renders(page: Page, route: str) -> None:
     """
     page.goto(route)
 
-    logo = page.locator('img[src="/public/neracoos.png"]').first
+    logo = page.locator('img[src="/static/neracoos.png"]').first
     # Once `complete` is true the browser has finished with the image, whether it
     # decoded or errored, so naturalWidth has settled. A 404 leaves the <img>
     # element in place with naturalWidth 0.
@@ -101,11 +101,25 @@ def test_health_endpoint_returns_200(api_request_context: APIRequestContext) -> 
 
 
 def test_public_logo_is_served(api_request_context: APIRequestContext) -> None:
-    """public/ is mounted, so the logo is fetchable as an image.
+    """The static route is mounted, so the logo is fetchable as an image.
 
     Checking the content type too, so that the catch-all marimo mount answering
     with an HTML page cannot pass this.
     """
-    response = api_request_context.get("/public/neracoos.png")
+    response = api_request_context.get("/static/neracoos.png")
     assert response.status == 200
     assert response.headers["content-type"].startswith("image/")
+
+
+def test_static_route_does_not_shadow_marimo(
+    api_request_context: APIRequestContext,
+) -> None:
+    """marimo's own /public-files-sw.js still reaches marimo.
+
+    granian matches --static-path-route as a plain string prefix rather than on
+    path segments, so serving the logo from a /public route would also swallow
+    this file -- and anything else whose path merely starts with those
+    characters -- and answer 404 instead of handing it to the app.
+    """
+    response = api_request_context.get("/public-files-sw.js?v=2")
+    assert response.status == 200


### PR DESCRIPTION
Follow-up to #112. This was ready ~9 minutes after that merged, so it needs its own PR — and the first half is a bug now live on `main`.

## `/public` swallows marimo's service worker

granian matches `--static-path-route` as a **plain string prefix**, not on path segments. With the route at `/public`, anything whose path merely *starts* with those characters is claimed by the static handler and 404s instead of reaching the app — including marimo's own `/public-files-sw.js`, which is fetched on every page load:

| route | `/public-files-sw.js?v=2` | `/publicity` |
|---|---|---|
| `/public` (on `main` now) | **404** | **404** |
| `/static` (this PR) | 200, from the app | 200, from the app |

So serve the logo from `/static` while the directory stays `public/`, and add a test for it. The e2e suite passed straight through that 404 — the service worker is an enhancement, not something the tests exercised, which is the same blind spot that let the original logo bug sit unnoticed.

## granian's access log was off

Unlike uvicorn, granian disables the access log by default, so the container log had no record of what the app was asked for — the view that turned up the logo 404s in the first place. `--access-log` turns it back on.

One caveat worth knowing: granian logs nothing for the static route, since it answers those without entering the app. So a future 404 on the logo itself would *not* appear in the container log; `tests/e2e/test_pages.py` is what covers that now.

This also matters for #111, whose inline filter keys off the access-log format — that PR accepts both uvicorn's `200 OK` and granian's `200 <duration>` tails, so it works either way.

## Verification

Against granian directly, with the final `serve` configuration:

```
/static/neracoos.png      -> 200 image/png 144580b
/public-files-sw.js?v=2   -> 200            (reaches the app)
/by_platform/             -> 200            (reaches the app)
/static/missing.png       -> 404
```

Access lines confirmed to match #111's filter. `ruff`, `pyproject-fmt` and `validate-pyproject` are clean, and `pixi install --locked` still accepts the existing lock — nothing here changes dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAo7VTsku1ned9LeQJ6JmK)_