### PR TITLE
Serve the logo from /static, and turn granian's access log on

### DIFF
--- a/common.py
+++ b/common.py
@@ -114,7 +114,7 @@ def sidebar_menu():
         [
             mo.Html("""
             <a href="https://neracoos.org">
-    <img src="/public/neracoos.png" />
+    <img src="/static/neracoos.png" />
     </a>
     """),
             mo.nav_menu(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,19 +65,29 @@ app = "marimo run climatology.py"
 # serve = "marimo run climatology.py --host 0.0.0.0 -p 8080 --base-url /climatology"
 
 # granian serves public/ itself, so requests for the logo never reach the app.
-# The route is absolute (/public) so it resolves identically from every
-# sub-mounted marimo app; see common.py's sidebar_menu().
+# The route is absolute so it resolves identically from every sub-mounted
+# marimo app; see common.py's sidebar_menu().
+#
+# The route is /static rather than /public even though the directory is
+# public/: granian matches the route as a plain string prefix, not on path
+# segments, so /public would also swallow marimo's own /public-files-sw.js
+# (and anything else starting with those characters) and 404 it.
 #
 # host and port are arguments so the e2e suite can bind a free port on
 # localhost without restating the static options -- see tests/e2e/conftest.py.
+#
+# granian disables the access log by default, unlike uvicorn. Keep it on: the
+# container log is the only view of what the app was asked for when an e2e run
+# fails. Note it still records nothing for /public, which granian answers
+# without entering the app -- tests/e2e/test_pages.py covers those instead.
 [tool.pixi.tasks.serve]
 args = [
   { arg = "host", default = "0.0.0.0" },
   { arg = "port", default = "8080" },
 ]
 cmd = """\
-  granian --interface asgi --host {{ host }} --port {{ port }} --static-path-route /public --static-path-mount public \
-  app:app\
+  granian --interface asgi --host {{ host }} --port {{ port }} --access-log --static-path-route /static \
+  --static-path-mount public app:app\
   """
 
 [tool.pixi.workspace]

--- a/tests/e2e/test_pages.py
+++ b/tests/e2e/test_pages.py
@@ -69,7 +69,7 @@ def test_sidebar_logo_renders(page: Page, route: str) -> None:
     """
     page.goto(route)
 
-    logo = page.locator('img[src="/public/neracoos.png"]').first
+    logo = page.locator('img[src="/static/neracoos.png"]').first
     # Once `complete` is true the browser has finished with the image, whether it
     # decoded or errored, so naturalWidth has settled. A 404 leaves the <img>
     # element in place with naturalWidth 0.
@@ -101,11 +101,25 @@ def test_health_endpoint_returns_200(api_request_context: APIRequestContext) -> 
 
 
 def test_public_logo_is_served(api_request_context: APIRequestContext) -> None:
-    """public/ is mounted, so the logo is fetchable as an image.
+    """The static route is mounted, so the logo is fetchable as an image.
 
     Checking the content type too, so that the catch-all marimo mount answering
     with an HTML page cannot pass this.
     """
-    response = api_request_context.get("/public/neracoos.png")
+    response = api_request_context.get("/static/neracoos.png")
     assert response.status == 200
     assert response.headers["content-type"].startswith("image/")
+
+
+def test_static_route_does_not_shadow_marimo(
+    api_request_context: APIRequestContext,
+) -> None:
+    """marimo's own /public-files-sw.js still reaches marimo.
+
+    granian matches --static-path-route as a plain string prefix rather than on
+    path segments, so serving the logo from a /public route would also swallow
+    this file -- and anything else whose path merely starts with those
+    characters -- and answer 404 instead of handing it to the app.
+    """
+    response = api_request_context.get("/public-files-sw.js?v=2")
+    assert response.status == 200


### PR DESCRIPTION
Two problems with routing the static mount at /public.

granian matches --static-path-route as a plain string prefix rather than on path segments, so /public also captured marimo's own /public-files-sw.js -- fetched on every page load -- and answered 404 instead of handing it to the app. Anything else beginning with those characters went the same way:

  route=/public   /public-files-sw.js?v=2 -> 404
  route=/static   /public-files-sw.js?v=2 -> 200 (from the app)

So serve the logo from /static while the directory stays public/, and cover it with a test, since the e2e suite passed straight through the 404: the service worker is an enhancement, not something the tests exercised.

granian also disables the access log by default, unlike uvicorn, which left the container log with no record of what the app was asked for -- the view that turned up this branch's original 404s. Turn it back on. Note it still logs nothing for the static route, which granian answers without entering the app, so tests/e2e/test_pages.py is what covers those now.

Verified against granian directly: /static/neracoos.png returns 200 image/png at full size, /public-files-sw.js and the app's own pages return 200, a missing static file returns 404, and the access lines match the inline filter in #111.