### PR TITLE
Catch the exceptions ERDDAP failures actually raise

### DIFF
--- a/by_platform.py
+++ b/by_platform.py
@@ -8,7 +8,6 @@ app = marimo.App(
 
 with app.setup:
     import altair as alt
-    import httpx
     import marimo as mo
     import pandas as pd
 
@@ -118,15 +117,14 @@ def _(time_series_selector):
                 _df = load_ts(_ts, col_name=_col_name)
                 loaded_ts[_key] = _df
                 unit_ts.setdefault(_unit, []).append(_col_name)
-            except httpx.HTTPError as e:
+            except common.ErddapLoadError as error:
                 mo.output.append(
                     common.admonition(
-                        "",
+                        str(error),
                         title=f"Unable to load data for {_col_name}",
                         kind="error",
                     ),
                 )
-                print(f"Error loading {_col_name}: \n{e}")
     return loaded_ts, unit_ts
 
 

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -155,7 +155,19 @@ def _(platform_options, selected_ts_keys, unit):
         with mo.status.spinner(title="Loading data from ERDDAP"):
             for _ts_name in selected_ts_keys.value:
                 _ts = platform_options[_ts_name]
-                _df = load_ts(_ts, _ts_name)
+                try:
+                    _df = load_ts(_ts, _ts_name)
+                except common.ErddapLoadError as error:
+                    # Keep going: one unavailable platform should not take the
+                    # whole comparison down with it.
+                    mo.output.append(
+                        common.admonition(
+                            str(error),
+                            title=f"Unable to load data for {_ts_name}",
+                            kind="error",
+                        ),
+                    )
+                    continue
                 with contextlib.suppress(KeyError):  # weird caching
                     del _df["Timeseries"]
                 # _df = _df.rename(columns={_ts["data_type"]["standard_name"]: _ts_name})

--- a/calculate_datums.py
+++ b/calculate_datums.py
@@ -82,8 +82,15 @@ def _(dataset_dropdown):
 
 
 @app.cell
-def _(dataset_id, erddapy, mo, use_qartod):
-    mo.stop(dataset_id is None)
+def _(common, dataset_id, erddapy, mo, use_qartod):
+    mo.stop(
+        dataset_id is None,
+        common.admonition(
+            "",
+            title="Please select a dataset to calculate datums for",
+            kind="warning",
+        ),
+    )
     e = erddapy.ERDDAP(
         server="https://data.neracoos.org/erddap",
         protocol="tabledap",
@@ -92,21 +99,28 @@ def _(dataset_id, erddapy, mo, use_qartod):
     e.dataset_id = dataset_id
     e.variables = ["time", "latitude", "longitude", "navd88_meters"]
     e.constraints = {"qartod_qc_rollup=": 1} if use_qartod.value else {}
+    e.requests_kwargs = {"timeout": common.ERDDAP_TIMEOUT}
     try:
         with mo.status.spinner("Loading data..."):
             df = e.to_pandas(index_col="time (UTC)", parse_dates=True).dropna()
-    except Exception as e:
-        mo.output.append(f"Error loading data: {e}")
-    # df
+    except Exception as error:
+        # Stop rather than appending: the cell used to fall through to
+        # `return (df,)` with df unbound, so a load failure surfaced as a
+        # NameError from a cell several steps downstream.
+        mo.stop(
+            True,
+            common.admonition(
+                f"Error loading data: {error}",
+                title="Data Load Error",
+                kind="error",
+            ),
+        )
     return (df,)
 
 
 @app.cell
-def _(df, mo):
-    try:
-        latitude = df["latitude (degrees_north)"].mean()
-    except NameError:
-        mo.stop(True)
+def _(df):
+    latitude = df["latitude (degrees_north)"].mean()
     return (latitude,)
 
 
@@ -131,12 +145,13 @@ def _(common, df_reset, latitude, longitude, mo, tadc):
                 Subordinate_Lat=latitude,
                 Subordinate_Lon=longitude,
             )
-    except Exception as e:
-        mo.output.append(
+    except Exception as error:
+        mo.stop(
+            True,
             common.admonition(
                 kind="error",
                 title="Error",
-                content=f"Error trying to calculate datums: {e}",
+                content=f"Error trying to calculate datums: {error}",
             ),
         )
     return (out,)

--- a/climatology.py
+++ b/climatology.py
@@ -7,8 +7,6 @@ with app.setup:
     from datetime import datetime, timedelta
 
     import altair as alt
-    import erddapy
-    import httpx2
     import marimo as mo
     import pandas as pd
 
@@ -33,16 +31,14 @@ def _():
 
 @app.cell
 def _():
-    platform_res = httpx2.get(
-        "https://buoybarn.neracoos.org/api/platforms/?visibility=climatology",
-    )
-    return (platform_res,)
+    platform_json = common.load_platform_json(visibility="climatology")
+    return (platform_json,)
 
 
 @app.cell
-def _(platform_res):
+def _(platform_json):
     platforms = {}
-    for feature in platform_res.json()["features"]:
+    for feature in platform_json["features"]:
         if feature["properties"]["station_name"]:
             platforms[feature["properties"]["station_name"]] = feature
         else:
@@ -150,26 +146,17 @@ def _(timeseries_dropdown):
 def _(ts):
     with mo.status.spinner(title="Loading data from ERDDAP"):
         try:
-            e = erddapy.ERDDAP(ts["server"], protocol="tabledap")
-            e.dataset_id = ts["dataset"]
-            e.variables = ["time", ts["variable"]]
-            e.constraints = ts["constraints"] or {}
-            df_all = e.to_pandas(
-                index_col="time (UTC)",
-                parse_dates=True,
-            ).dropna()
-        except TypeError:
-            mo.stop(True)
-        except httpx2.HTTPError as e:
+            df_all = common.load_ts_from_erddap(ts)
+        except common.ErddapLoadError as error:
             mo.stop(
                 True,
                 common.admonition(
-                    "Error loading data from ERDDAP",
+                    str(error),
                     title="Data Load Error",
                     kind="error",
                 ),
             )
-    return df_all, e
+    return (df_all,)
 
 
 @app.cell
@@ -508,13 +495,13 @@ def _(area, line, logo, mean, ts):
 
 
 @app.cell
-def _(e, end_year_dropdown, platform, start_year_dropdown):
+def _(end_year_dropdown, platform, start_year_dropdown, ts):
     mo.hstack(
         [
             mo.md(
                 f"[Platform on Mariners Dashboard](https://mariners.neracoos.org/platform/{platform['id']})",
             ),
-            mo.md(f"[Dataset on ERDDAP]({e.get_download_url()})"),
+            mo.md(f"[Dataset on ERDDAP]({common.erddap_download_url(ts)})"),
             mo.md(
                 f"Climatology calculated from {start_year_dropdown.value} to {end_year_dropdown.value}",
             ),


### PR DESCRIPTION
Stacked on #125.

## Why

erddapy 3.2.1 talks to ERDDAP with `requests` -- confirmed in `pixi.lock`, which lists `requests` and no httpx under the erddapy package. So:

- `by_platform.py` caught `httpx.HTTPError`
- `climatology.py` caught `httpx2.HTTPError`
- `by_standard_name.py` caught nothing

None of those can ever match a `requests` exception, so every "nicer error when ERDDAP gets cranky" path was dead code and a failed load reached the user as a raw traceback. All three now catch `common.ErddapLoadError` and show the reason in the admonition that was already written for it.

## Also in here

- **No request timeouts anywhere.** Both loaders now pass one. This is the most plausible explanation for the NDBC datasets in #38 that "hang up and not load data in the visualizations": with no timeout, a slow or oversized dataset pins the marimo kernel indefinitely and the page just sits there. A timeout plus a visible error at least tells you what happened. (The SE backfill in that issue is still an ops task.)
- **`climatology.py` fetched Buoy Barn by hand**, skipping the status check the shared loader does, so an API error surfaced as `KeyError: 'features'` rather than a message. It now uses `common.load_platform_json(visibility="climatology")`, which also means the response is cached like the other pages.
- **`by_standard_name.py` now skips a platform it cannot load** instead of losing the entire comparison to one bad series.
- **`calculate_datums.py`**: `except Exception as e` shadowed the `erddapy.ERDDAP` client also named `e`, and both handlers appended a message and then fell through to `return (df,)` / `return (out,)` with the name never bound -- so a load failure surfaced as a `NameError` from a cell several steps downstream. Both stop cleanly now, which also makes the `except NameError` guard below them dead code, so it is gone. Selecting no dataset now says so instead of stopping silently.

The shadowed `e` in `climatology.py` goes away here too, since the download URL comes from `common.erddap_download_url(ts)` rather than from the client the loader used to leak out of its cell.

## Verified

- 38 unit tests pass, including two recorded cases covering a transport failure and the non-CSV body ERDDAP answers a rejected request with.
- Full Playwright suite run locally against the real services: 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)