### PR TITLE
Fix the compare pages' crashes on the small-data path

### DIFF
--- a/by_platform.py
+++ b/by_platform.py
@@ -39,46 +39,29 @@ def _():
 
 @app.cell
 def _(platform_json):
-    platforms = {
-        p["properties"]["station_name"] or p["id"]: p for p in platform_json["features"]
-    }
+    platforms = common.platforms_by_name(platform_json)
     return (platforms,)
 
 
 @app.cell
 def _(platforms):
     platform_selector = mo.ui.dropdown(
-        dict(sorted(platforms.items())),
+        platforms,
         label="Select platform",
     )
     return (platform_selector,)
 
 
-@app.function
-def name_for_ts(ts: dict):
-    name = ts["data_type"]["long_name"]
-    if ts["depth"]:
-        name = f"{name} @ {ts['depth']} meters"
-
-    return name
-
-
 @app.cell
 def _(platform_selector):
-    platform_time_series = {}
-
-    if platform_selector.value:
-        for _ts in platform_selector.value["properties"]["readings"]:
-            _name = name_for_ts(_ts)
-
-            platform_time_series[_name] = _ts
+    platform_time_series = common.timeseries_by_name(platform_selector.value)
     return (platform_time_series,)
 
 
 @app.cell
 def _(platform_time_series):
     time_series_selector = mo.ui.multiselect(
-        dict(sorted(platform_time_series.items())),
+        platform_time_series,
         label="Select time series",
     )
     return (time_series_selector,)
@@ -89,20 +72,6 @@ def _(platform_selector, time_series_selector):
     mo.hstack([platform_selector, time_series_selector])
 
 
-@app.function
-@mo.cache
-def load_ts(ts: dict, col_name: str | None = None) -> pd.DataFrame:
-    df = common.load_ts_from_erddap(ts)
-
-    if not col_name:
-        col_name = ts["data_type"]["standard_name"]
-
-    columns = list(df.columns)
-    columns[0] = col_name
-    df.columns = columns
-    return df
-
-
 @app.cell
 def _(time_series_selector):
     loaded_ts = {}
@@ -110,11 +79,11 @@ def _(time_series_selector):
 
     with mo.status.spinner(title="Loading data from ERDDAP"):
         for _ts in time_series_selector.value:
-            _col_name = name_for_ts(_ts)
+            _col_name = common.name_for_ts(_ts)
             _unit = _ts["data_type"]["units"]
             _key = (_col_name, _unit)
             try:
-                _df = load_ts(_ts, col_name=_col_name)
+                _df = common.load_ts(_ts, _col_name)
                 loaded_ts[_key] = _df
                 unit_ts.setdefault(_unit, []).append(_col_name)
             except common.ErddapLoadError as error:
@@ -173,28 +142,23 @@ def _(date_range, df, unit_ts):
     except NameError:
         mo.stop(True)
 
-    MAX_ROWS = 10_000 / len(list(unit_ts.keys()))
+    # The subplots share one budget, so comparing four units does not inline
+    # four times as much data into the vega spec as comparing one.
+    _max_rows = common.MAX_ROWS // max(len(unit_ts), 1)
 
-    def time_grouper(df: pd.DataFrame) -> pd.DataFrame:
-        filtered_df = df
+    filtered_df, _resampled_to = common.resample_to_budget(
+        time_filtered_df,
+        _max_rows,
+    )
 
-        if len(filtered_df) < MAX_ROWS:
-            mo.output.append(mo.callout("No filtering needed"))
-            return df[0]
-        for time_period, name in common.TIME_GROUPS:
-            filtered_df = df.resample(time_period).mean()
-            if len(filtered_df) < MAX_ROWS:
-                mo.output.append(
-                    common.admonition(
-                        "",
-                        title=f"Resampled to {name} means for plotting",
-                        kind="attention",
-                    ),
-                )
-                return filtered_df
-        return filtered_df
-
-    filtered_df = time_grouper(time_filtered_df)
+    if _resampled_to:
+        mo.output.append(
+            common.admonition(
+                "",
+                title=f"Resampled to {_resampled_to} means for plotting",
+                kind="attention",
+            ),
+        )
     return (filtered_df,)
 
 
@@ -212,10 +176,14 @@ def _(filtered_df, platform_selector, unit_ts):
 
     stack = alt.vconcat()
     for i, (_unit, _ts_keys) in enumerate(unit_ts.items()):
-        # _row_df = pd.melt(filtered_df[_ts_keys].reset_index(), id_vars="time (UTC)").dropna()
-        # _row_df = _row_df.rename(columns={"value": _unit})
-        # _row = alt.Chart(_row_df).mark_line().encode(x="time (UTC)", y=_unit, color="variable").properties(height=300)
-        _row = _base.encode(x="time (UTC):T", y=f"{_unit}:Q", color="variable")
+        # Every subplot draws from the one melted frame, so without the filter
+        # each takes its colour domain from all of the series -- listing the
+        # other units' series in its legend and drawing them as nulls.
+        _row = _base.encode(
+            x="time (UTC):T",
+            y=f"{_unit}:Q",
+            color="variable",
+        ).transform_filter(alt.FieldOneOfPredicate(field="variable", oneOf=_ts_keys))
         if i == 0:
             _row = _row + common.neracoos_logo(
                 filtered_df.index.max(),

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -131,24 +131,13 @@ def _(selected_ts_keys):
         selected_ts_keys.value
     except AttributeError:
         mo.stop(
+            True,
             common.admonition("Please select platforms to display", kind="attention"),
         )
 
 
-@app.function
-@mo.cache
-def load_ts(ts: dict, col_name: str) -> pd.DataFrame:
-    df = common.load_ts_from_erddap(ts)
-    columns = list(df.columns)
-    columns[0] = col_name
-    df.columns = columns
-    return df
-
-
 @app.cell
 def _(platform_options, selected_ts_keys, unit):
-    import contextlib
-
     _wide_dfs = []
 
     try:
@@ -156,7 +145,7 @@ def _(platform_options, selected_ts_keys, unit):
             for _ts_name in selected_ts_keys.value:
                 _ts = platform_options[_ts_name]
                 try:
-                    _df = load_ts(_ts, _ts_name)
+                    _df = common.load_ts(_ts, _ts_name)
                 except common.ErddapLoadError as error:
                     # Keep going: one unavailable platform should not take the
                     # whole comparison down with it.
@@ -168,9 +157,6 @@ def _(platform_options, selected_ts_keys, unit):
                         ),
                     )
                     continue
-                with contextlib.suppress(KeyError):  # weird caching
-                    del _df["Timeseries"]
-                # _df = _df.rename(columns={_ts["data_type"]["standard_name"]: _ts_name})
                 if not _df.index.is_unique:
                     _df = _df.loc[~_df.index.duplicated(keep="first")]
                 _wide_dfs.append(_df)
@@ -207,30 +193,6 @@ def _(wide_df):
     return (date_range,)
 
 
-@app.function
-def time_grouper(df: pd.DataFrame) -> pd.DataFrame:
-    filtered_df = df
-
-    if len(filtered_df) < common.MAX_ROWS:
-        print("No aggregation needed")
-        return df
-    for time_period, name in common.TIME_GROUPS:
-        print(f"Trying to group by {time_period}")
-        filtered_df = df.groupby(pd.Grouper(freq=time_period)).apply(
-            lambda x: x.groupby("Timeseries").mean(),
-        )
-        if len(filtered_df) < common.MAX_ROWS:
-            mo.output.append(
-                common.admonition(
-                    "",
-                    title=f"Resampled to {name} means for plotting",
-                    kind="attention",
-                ),
-            )
-            return filtered_df
-    return filtered_df
-
-
 @app.cell
 def _(date_range, wide_melted):
     try:
@@ -241,23 +203,33 @@ def _(date_range, wide_melted):
     except AttributeError:
         mo.stop(True)
 
-    filtered_df = time_grouper(time_filtered_df)
+    filtered_df, _resampled_to = common.resample_to_budget(
+        time_filtered_df,
+        by="Timeseries",
+    )
+
+    if _resampled_to:
+        mo.output.append(
+            common.admonition(
+                "",
+                title=f"Resampled to {_resampled_to} means for plotting",
+                kind="attention",
+            ),
+        )
     return (filtered_df,)
 
 
 @app.cell
 def _(filtered_df, standard_name_dropdown, standards, unit):
-    alt.data_transformers.disable_max_rows()
-
     _logo = common.neracoos_logo(
-        filtered_df.index.max()[0],
+        filtered_df.index.max(),
         standards[standard_name_dropdown.value]["long_name"],
     )
 
     _chart = (
         alt.Chart(filtered_df.reset_index())
         .mark_line()
-        .encode(x="time (UTC)", y=unit, color="Timeseries")
+        .encode(x="time (UTC):T", y=f"{unit}:Q", color="Timeseries")
     )
     _chart = _chart.properties(width="container")
 


### PR DESCRIPTION
Stacked on #126.

## The bug

Both compare pages had their own copy of a resampler that shrinks the data until it fits the inline-data budget. Each copy was written for one of its two paths and broken on the other:

| Page | Broken path | Symptom |
| --- | --- | --- |
| `by_platform.py` | data small enough to plot as-is | `return df[0]` → `KeyError: 0` |
| `by_standard_name.py` | data small enough to plot as-is | chart cell does `filtered_df.index.max()[0]`, but the MultiIndex that subscript expects only exists when it *did* resample → `TypeError: 'Timestamp' object is not subscriptable` |

Neither is reachable from the e2e suite: every case there picks a wide enough range that the resampled path is taken. Pick a short date range, or a series with little data, and the page dies.

Both now call `common.resample_to_budget` from #125, which returns the same index shape whether or not it resampled and is unit tested on both paths.

## Carried along

- **Performance.** `by_standard_name` used `groupby(pd.Grouper(...)).apply(lambda x: x.groupby("Timeseries").mean())` -- a Python-level loop over every time bucket, run up to three times as it tried successively coarser periods. It is one grouped mean now.
- **`disable_max_rows()`** is gone. Combined with the inline-CSV transformer it let unbounded data be embedded in the page regardless of the budget the resampler had just computed.
- **`mo.stop(admonition)`** in `by_standard_name` passed the message where the predicate goes, so the "Please select platforms to display" callout never rendered. It needs `mo.stop(True, ...)`.
- **Cache mutation.** Both pages now use `common.load_ts`, which returns a copy. `del _df["Timeseries"]` was mutating the object `@mo.cache` handed back -- that is what the `# weird caching` comment and its `contextlib.suppress(KeyError)` were papering over.
- **Subplot legends.** Every stacked subplot in `by_platform` drew from the one melted frame, so each computed its colour domain over *all* the series and listed the other units' series in its legend, drawn as nulls. A `transform_filter` scopes each subplot to its own unit, client-side, without duplicating the dataset per subplot.
- **Naming.** `name_for_ts` and the platform dict come from `common` now, so the three copies of each cannot drift. One visible change: `by_platform`'s depth labels go from `@ 1.0 meters` to `@ 1.0m`, matching the climatology page.

## Verified

- 38 unit tests pass; `resample_to_budget` is covered on the pass-through path, the resampled path, the fall-through to the coarsest period, and for per-series averaging.
- Full Playwright suite locally: 17 passed.
- The pass-through path was also exercised end-to-end outside the browser against live data (two series, a 7-day range → 865 rows, `label=None`, flat `DatetimeIndex`, valid vega spec with the per-subplot filter).

I tried adding an e2e case that sets a short date range through the UI, but filling marimo's date inputs from Playwright hung the run indefinitely rather than failing, so I dropped it -- the unit tests cover the branch the bug was actually in. Worth a follow-up if we want UI-level coverage of the date range control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)