### PR TITLE
Wire the climatology page onto the shared core

### DIFF
--- a/climatology.py
+++ b/climatology.py
@@ -4,12 +4,10 @@ __generated_with = "0.14.0"
 app = marimo.App(width="medium", app_title="NERACOOS Climatology")
 
 with app.setup:
-    from datetime import datetime, timedelta
-
     import altair as alt
     import marimo as mo
-    import pandas as pd
 
+    import climatology_core as core
     import common
 
 
@@ -37,13 +35,7 @@ def _():
 
 @app.cell
 def _(platform_json):
-    platforms = {}
-    for feature in platform_json["features"]:
-        if feature["properties"]["station_name"]:
-            platforms[feature["properties"]["station_name"]] = feature
-        else:
-            platforms[feature["id"]] = feature
-    platforms = dict(sorted(platforms.items()))
+    platforms = common.platforms_by_name(platform_json)
     return (platforms,)
 
 
@@ -58,7 +50,7 @@ def _(platforms, query_params):
     platform_dropdown = mo.ui.dropdown(
         options=platforms.keys(),
         label="Platform",
-        value=query_params.get("platform", None),
+        value=common.query_param_default(query_params, "platform", platforms),
         on_change=lambda value: query_params.set("platform", value),
     )
     return (platform_dropdown,)
@@ -66,45 +58,27 @@ def _(platforms, query_params):
 
 @app.cell
 def _(platform_dropdown, platforms):
-    try:
-        platform = platforms[platform_dropdown.value]
-    except KeyError:
-        platform = None
+    platform = platforms.get(platform_dropdown.value)
     return (platform,)
 
 
 @app.cell
 def _(platform):
-    timeseries = {}
-
-    try:
-        for r in platform["properties"]["readings"]:
-            if r["depth"]:
-                name = f"{r['data_type']['long_name']} @ {r['depth']}m"
-
-            else:
-                name = r["data_type"]["long_name"]
-            r["app_name"] = name
-            timeseries[name] = r
-    except TypeError:
-        # mo.stop(True)
-        pass
-    timeseries = dict(sorted(timeseries.items()))
+    timeseries = common.timeseries_by_name(platform)
     return (timeseries,)
 
 
 @app.cell
 def _(query_params, timeseries):
-    if query_params["ts"] and query_params["ts"] in timeseries:
-        timeseries_default = query_params["ts"]
-    else:
-        timeseries_default = None
-
     timeseries_dropdown = mo.ui.dropdown(
         options=timeseries,
         label="Data Type",
-        value=timeseries_default,
-        on_change=lambda value: query_params.set("ts", value["app_name"]),
+        value=common.query_param_default(query_params, "ts", timeseries),
+        # Guarded: clearing the dropdown hands the callback None, and None has
+        # no app_name.
+        on_change=lambda value: (
+            query_params.set("ts", value["app_name"]) if value else None
+        ),
     )
     return (timeseries_dropdown,)
 
@@ -162,24 +136,24 @@ def _(ts):
 @app.cell
 def _(df_all):
     df_no_index = df_all.reset_index()
-    df_no_index = df_no_index.rename({"time (UTC)": "Date"}, axis=1)
+    df_no_index = df_no_index.rename({"time (UTC)": core.TIME_COLUMN}, axis=1)
     column = df_all.columns[0]
     return column, df_no_index
 
 
 @app.cell
-def _(df_all, query_params):
-    years = [str(y) for y in df_all.index.year.unique()]
-
-    if query_params["year"] and query_params["year"] in years:
-        years_default = query_params["year"]
-    else:
-        years_default = years[-1]
+def _(df_no_index, query_params):
+    years = core.available_years(df_no_index)
 
     year_dropdown = mo.ui.dropdown(
         options=years,
         label="Select a year to display",
-        value=years_default,
+        value=common.query_param_default(
+            query_params,
+            "year",
+            years,
+            fallback=years[-1],
+        ),
         on_change=lambda value: query_params.set("year", value),
     )
     year_dropdown
@@ -187,22 +161,16 @@ def _(df_all, query_params):
 
 
 @app.cell
-def _(year_dropdown):
-    year = datetime(int(year_dropdown.value), 1, 1)
-    return (year,)
-
-
-@app.cell
 def _(query_params, years):
-    if query_params["clim_start"] and query_params["clim_start"] in years:
-        start_year_default = query_params["clim_start"]
-    else:
-        start_year_default = years[0]
-
     start_year_dropdown = mo.ui.dropdown(
         options=years,
         label="Select a year to start generating the climatology",
-        value=start_year_default,
+        value=common.query_param_default(
+            query_params,
+            "clim_start",
+            years,
+            fallback=years[0],
+        ),
         on_change=lambda value: query_params.set("clim_start", value),
     )
     # start_year_dropdown
@@ -211,25 +179,17 @@ def _(query_params, years):
 
 @app.cell
 def _(query_params, start_year_dropdown, years):
-    years_greater_than_start = [
-        y for y in years if int(start_year_dropdown.value) < int(y)
-    ]
-
-    if (
-        query_params["clim_end"]
-        and query_params["clim_end"] in years_greater_than_start
-    ):
-        end_year_default = query_params["clim_end"]
-    else:
-        try:
-            end_year_default = years_greater_than_start[-2]
-        except IndexError:
-            end_year_default = years_greater_than_start[-1]
+    _end_year_options = core.end_year_options(years, start_year_dropdown.value)
 
     end_year_dropdown = mo.ui.dropdown(
-        options=years_greater_than_start,
+        options=_end_year_options,
         label="Select an end year for the climatology",
-        value=end_year_default,
+        value=common.query_param_default(
+            query_params,
+            "clim_end",
+            _end_year_options,
+            fallback=core.default_end_year(_end_year_options),
+        ),
         on_change=lambda value: query_params.set("clim_end", value),
     )
     # end_year_dropdown
@@ -238,15 +198,13 @@ def _(query_params, start_year_dropdown, years):
 
 @app.cell
 def _(query_params):
-    DAILY = "Daily"
-    MONTHLY = "Monthly"
     average_period_dropdown = mo.ui.dropdown(
-        options=[DAILY, MONTHLY],
+        options=[core.DAILY, core.MONTHLY],
         label="Averaging Time Period",
-        value=query_params["avg_period"] or DAILY,
+        value=query_params["avg_period"] or core.DAILY,
         on_change=lambda value: query_params.set("avg_period", value),
     )
-    return DAILY, average_period_dropdown
+    return (average_period_dropdown,)
 
 
 @app.cell
@@ -255,49 +213,26 @@ def _(average_period_dropdown, end_year_dropdown, start_year_dropdown):
 
 
 @app.cell
-def _(DAILY, average_period_dropdown, column, df_no_index):
-    if average_period_dropdown.value == DAILY:
-        means = (
-            df_no_index[column]
-            .groupby(df_no_index["Date"].dt.date)
-            .agg(["mean", "count"])
-        )
-        # _over_time_chart = alt.Chart(means.reset_index()).mark_line().encode(alt.Y("count"), alt.X("Date"))
-        _threshold_chart = (
-            alt.Chart(means)
-            .mark_bar()
-            .encode(alt.X("count", bin=True, title="Values per day"), y="count()")
-        )
-        threshold = mo.ui.number(
-            start=0,
-            stop=int(means["count"].max()),
-            step=1,
-            value=18,
-            label="Minimum number of daily values",
-        )
-    else:
-        means = (
-            df_no_index[column]
-            .groupby(df_no_index["Date"].dt.strftime("%Y-%m"))
-            .agg(["mean", "count"])
-        )
-        _threshold_chart = (
-            alt.Chart(means)
-            .mark_bar()
-            .encode(
-                alt.X("count", bin=True, title="Values per month"),
-                y="count()",
-            )
-        )
-        threshold = mo.ui.number(
-            start=0,
-            stop=int(means["count"].max()),
-            step=1,
-            value=20,
-            label="Minimum number of monthly values",
-        )
+def _(average_period_dropdown, column, df_no_index):
+    _period = average_period_dropdown.value
+    means = core.period_means(df_no_index, column, _period)
 
-    means.index = pd.to_datetime(means.index)
+    _per = "day" if _period == core.DAILY else "month"
+    _threshold_chart = (
+        alt.Chart(means)
+        .mark_bar()
+        .encode(
+            alt.X("count", bin=True, title=f"Values per {_per}"),
+            y="count()",
+        )
+    )
+    threshold = mo.ui.number(
+        start=0,
+        stop=int(means["count"].max()),
+        step=1,
+        value=core.threshold_default(_period),
+        label=f"Minimum number of {'daily' if _period == core.DAILY else 'monthly'} values",
+    )
 
     mo.accordion(
         {
@@ -324,82 +259,59 @@ def _(DAILY, average_period_dropdown, column, df_no_index):
 
 @app.cell
 def _(end_year_dropdown, means, start_year_dropdown, threshold):
-    means_filtered = means[
-        (means["count"] > threshold.value)
-        & (start_year_dropdown.value <= means.index)
-        & (means.index < str(int(end_year_dropdown.value) + 1))
-    ]
+    means_filtered = core.filter_means(
+        means,
+        threshold=threshold.value,
+        start_year=start_year_dropdown.value,
+        end_year=end_year_dropdown.value,
+    )
     # means_filtered
     return (means_filtered,)
 
 
 @app.cell
 def _(
-    DAILY,
     average_period_dropdown,
     end_year_dropdown,
     means_filtered,
     start_year_dropdown,
-    year,
+    year_dropdown,
 ):
-    if average_period_dropdown.value == DAILY:
-        clim_group_by = means_filtered.index.day_of_year
-    else:
-        clim_group_by = means_filtered.index.month
+    _period = average_period_dropdown.value
+    time_col = core.time_column(_period)
 
-    clim_df = (
-        means_filtered.groupby(clim_group_by)["mean"]
-        .agg(["mean", "max", "min", "idxmin", "idxmax"])
-        .reset_index()
-    )
-
-    clim_df["idxmin"] = clim_df["idxmin"].dt.date
-    clim_df["idxmax"] = clim_df["idxmax"].dt.date
-
-    if average_period_dropdown.value == DAILY:
-        clim_df["Date"] = clim_df["Date"].apply(
-            lambda x: year + timedelta(days=x - 1),
-        )
-        clim_df = clim_df.rename(
-            columns={"idxmin": "Min date", "idxmax": "Max date"},
-        )
-    else:
-        clim_df["Date"] = pd.to_datetime(
-            clim_df["Date"].apply(lambda x: f"{year.year}-{x}"),
-        )
-        clim_df = clim_df.rename(
-            {
-                "Date": "Month",
-                "idxmin": "Min month",
-                "idxmax": "Max month",
-            },
-            axis=1,
-        )
+    clim_df = core.climatology(means_filtered, _period, year_dropdown.value)
 
     _range = f"({start_year_dropdown.value} - {end_year_dropdown.value})"
-
     mean_range_name = f"Mean {_range}"
     min_range_name = f"Min {_range}"
     max_range_name = f"Max {_range}"
-    clim_df = clim_df.round(2).rename(
+
+    _when = "date" if _period == core.DAILY else "month"
+    min_date_name = f"Min {_when}"
+    max_date_name = f"Max {_when}"
+
+    # Rounded by name rather than frame-wide: pandas warns that round() has no
+    # effect on the date columns sitting alongside these.
+    clim_df = clim_df.round({"mean": 2, "min": 2, "max": 2}).rename(
         columns={
             "mean": mean_range_name,
             "min": min_range_name,
             "max": max_range_name,
+            "min_date": min_date_name,
+            "max_date": max_date_name,
         },
     )
-    return clim_df, max_range_name, mean_range_name, min_range_name
+    return clim_df, max_range_name, mean_range_name, min_range_name, time_col
 
 
 @app.cell
-def _(average_period_dropdown, clim_df, max_range_name, min_range_name):
+def _(clim_df, max_range_name, min_range_name, time_col):
     area = (
         alt.Chart(clim_df)
         .mark_area(color="yellow", opacity=0.5)
         .encode(
-            alt.X("Date")
-            if average_period_dropdown.value == "Daily"
-            else alt.X("Month"),
+            alt.X(time_col, type="temporal"),
             alt.Y(min_range_name),
             alt.Y2(max_range_name),
         )
@@ -408,14 +320,12 @@ def _(average_period_dropdown, clim_df, max_range_name, min_range_name):
 
 
 @app.cell
-def _(average_period_dropdown, clim_df, mean_range_name):
+def _(clim_df, mean_range_name, time_col):
     mean = (
         alt.Chart(clim_df)
         .mark_line()
         .encode(
-            alt.X("Date")
-            if average_period_dropdown.value == "Daily"
-            else alt.X("Month"),
+            alt.X(time_col, type="temporal"),
             alt.Y(mean_range_name),
         )
     )
@@ -423,43 +333,25 @@ def _(average_period_dropdown, clim_df, mean_range_name):
 
 
 @app.cell
-def _(average_period_dropdown, column, df_no_index, year, year_dropdown):
-    df_year = df_no_index[
-        (f"{year_dropdown.value}-01-01T00:00" < df_no_index["Date"])
-        & (df_no_index["Date"] < f"{year_dropdown.value}-12-31T23:59:59")
-    ]
-
-    if average_period_dropdown.value == "Daily":
-        year_group_by = df_year["Date"].dt.day_of_year
-    else:
-        year_group_by = df_year["Date"].dt.month
-
-    df_year = df_year.groupby(year_group_by)[column].agg(["mean"])
-    df_year = df_year.reset_index()
-
-    if average_period_dropdown.value == "Daily":
-        df_year["Date"] = df_year["Date"].apply(
-            lambda x: year + timedelta(days=x - 1),
-        )
-    else:
-        df_year["Date"] = pd.to_datetime(
-            df_year["Date"].apply(lambda x: f"{year.year}-{x}"),
-        )
-        df_year = df_year.rename({"Date": "Month"}, axis=1)
+def _(average_period_dropdown, column, df_no_index, year_dropdown):
+    df_year = core.year_series(
+        df_no_index,
+        column,
+        average_period_dropdown.value,
+        year_dropdown.value,
+    )
     return (df_year,)
 
 
 @app.cell
-def _(average_period_dropdown, df_year, ts):
+def _(df_year, time_col, ts):
     _y_title = f"{ts['data_type']['long_name']} ({ts['data_type']['units']})"
 
     line = (
         alt.Chart(df_year)
         .mark_point(color="red")
         .encode(
-            alt.X("Date")
-            if average_period_dropdown.value == "Daily"
-            else alt.X("Month"),
+            alt.X(time_col, type="temporal"),
             alt.Y("mean").title(_y_title),
         )
     )
@@ -468,18 +360,18 @@ def _(average_period_dropdown, df_year, ts):
 
 @app.cell
 def _(
-    average_period_dropdown,
     clim_df,
     end_year_dropdown,
     platform,
     start_year_dropdown,
+    time_col,
     ts,
     year_dropdown,
 ):
     logo = common.neracoos_logo(
-        clim_df["Date"].max(),
+        clim_df[time_col].max(),
         f"{ts['app_name']} at {platform['id']} for {start_year_dropdown.value} thru {max([end_year_dropdown.value, year_dropdown.value])}",
-        time_col="Date" if average_period_dropdown.value == "Daily" else "Month",
+        time_col=time_col,
     )
     return (logo,)
 
@@ -510,45 +402,33 @@ def _(end_year_dropdown, platform, start_year_dropdown, ts):
 
 
 @app.cell
-def _(
-    DAILY,
-    average_period_dropdown,
-    clim_df,
-    df_year,
-    end_year_dropdown,
-    start_year_dropdown,
-    year_dropdown,
-):
-    _range = f"({start_year_dropdown.value} - {end_year_dropdown.value})"
+def _(average_period_dropdown, clim_df, df_year, time_col, year_dropdown):
+    _period = average_period_dropdown.value
+    _year_column = (
+        f"{'Daily' if _period == core.DAILY else 'Monthly'} means"
+        f" for {year_dropdown.value}"
+    )
+
     df_combined = clim_df.merge(
-        df_year.rename(
-            {
-                "mean": f"{'Daily' if average_period_dropdown.value == DAILY else 'Monthly'} means for {year_dropdown.value}",
-            },
-            axis=1,
-        ),
-        on=("Date" if average_period_dropdown.value == DAILY else "Month"),
+        df_year.rename({"mean": _year_column}, axis=1),
+        on=time_col,
         how="left",
     )
 
-    if average_period_dropdown.value == DAILY:
-        df_combined["Date"] = df_combined["Date"].dt.date
+    if _period == core.DAILY:
+        df_combined[time_col] = df_combined[time_col].dt.date
 
-        _cols = [
-            df_combined.columns.to_list()[0],
-            *df_combined.columns.to_list()[-1:],
-            *df_combined.columns.to_list()[1:-1],
-        ]
-        df_combined = df_combined[_cols]
-    else:
-        _cols = [
-            df_combined.columns.to_list()[0],
-            *df_combined.columns.to_list()[-1:],
-            *df_combined.columns.to_list()[2:-1],
-        ]
-        df_combined = df_combined[_cols]
-
-    df_combined = df_combined.round(2)
+    # Named rather than sliced by position: the slicing this replaces dropped
+    # the mean column outright from the monthly table.
+    _columns = [
+        time_col,
+        _year_column,
+        *(c for c in df_combined.columns if c not in (time_col, _year_column)),
+    ]
+    df_combined = df_combined[_columns]
+    df_combined = df_combined.round(
+        dict.fromkeys(df_combined.select_dtypes("number").columns, 2),
+    )
 
     mo.accordion({"Show data": df_combined})
 

--- a/tests/e2e/test_climatology.py
+++ b/tests/e2e/test_climatology.py
@@ -19,3 +19,12 @@ def test_western_maine_shelf_air(page: Page) -> None:
     assert_chart_rendered(page)
 
     assert download_chart_png(page).suggested_filename.endswith(".png")
+
+
+def test_monthly_averaging_period(page: Page) -> None:
+    """Monthly used to die on `clim_df["Date"]` after that column was renamed
+    to "Month", so the whole averaging period was unreachable."""
+    page.goto("/climatology/?platform=Western+Maine+Shelf&ts=Air+Temperature")
+    page.get_by_label("Averaging Time Period").select_option("Monthly")
+
+    assert_chart_rendered(page)


### PR DESCRIPTION
Stacked on #128.

## Three bugs this fixes

**Monthly was completely dead.** The monthly branch renamed its time column from `Date` to `Month` (climatology.py:383), and then the logo cell asked for `clim_df["Date"].max()` (climatology.py:494) -- `KeyError`. Selecting the Monthly averaging period never rendered a chart. The e2e suite only ever drove the Daily default, so nothing caught it. There is now an e2e case for Monthly.

The root cause was the four copies of `alt.X("Date") if average_period_dropdown.value == "Daily" else alt.X("Month")` scattered across the chart cells, with a fifth place getting it wrong. There is one `time_col` now.

**Midnight on Jan 1 was dropped.** The selected year was filtered with `f"{year}-01-01T00:00" < df["Date"]` -- strictly greater, so an observation at exactly midnight on Jan 1 fell outside its own year. It is `.dt.year ==` now.

**Clearing the Data Type dropdown raised TypeError.** `on_change=lambda value: query_params.set("ts", value["app_name"])` reaches into `None` when the dropdown is cleared.

Also picked up from #125: choosing the newest year as the climatology start used to leave the end-year list empty and raise `IndexError` from the default below it.

## Two timezone bugs found while wiring this up

Both were in #125 and are amended into it rather than fixed here, so that branch is correct on its own. Worth flagging because neither was visible from the unit tests -- my test data was naive, real ERDDAP data is `datetime64[us, UTC]`:

- `filter_means` compared a UTC-aware index against a naive `pd.Timestamp`, which pandas rejects outright. The string bounds it replaced happened to parse into an aware timestamp, which is why the original worked.
- `period_means` went through `to_period("M")` for the monthly key, which silently drops the timezone -- so the monthly index came back naive while the daily one was aware.

The unit tests now build UTC-aware observations by default and assert the monthly index keeps its timezone.

## Smaller things

- The monthly data table selected columns by position (`columns[2:-1]`) and dropped the mean column outright. Columns are named now. This was invisible before because the monthly page crashed before reaching the table.
- `round(2)` is applied per column rather than frame-wide; pandas warns that it does nothing to the date columns sitting alongside the numbers.
- `pandas`, `erddapy`, `datetime` and `timedelta` imports are gone from the page -- the core owns that work now.

## Verified

- 40 unit tests pass.
- Full Playwright suite locally: **18 passed**, including the new Monthly case.
- Both averaging periods driven end-to-end against live Buoy Barn and ERDDAP data outside the browser: Daily 366 climatology rows / 208 year rows, Monthly 12 / 8, valid 4-layer vega spec and a correctly joined table for each.

One thing the live run made visible: the Daily climatology returns 366 rows and maps day 366 onto Jan 1 of the *following* year. That is the leap-year misalignment, fixed in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)