### PR TITLE
Align daily climatology on calendar days, not day of year

### DIFF
--- a/climatology_core.py
+++ b/climatology_core.py
@@ -23,6 +23,9 @@ MONTH_COLUMN = "Month"
 # Internal name for the group key a period average is collected under.
 _PERIOD = "_period"
 
+# The one calendar day that has nowhere to land in three years out of four.
+_LEAP_DAY = "02-29"
+
 
 def threshold_default(period: str) -> int:
     """Default minimum observation count for an averaging period."""
@@ -66,19 +69,54 @@ def _period_keys(times, period: str):
 
     Accepts a Series or a DatetimeIndex, since observations arrive as a column
     and period averages as an index.
+
+    Daily keys are the calendar month and day rather than the day of the year:
+    day 60 is Feb 29 in a leap year and Mar 1 in every other one, so keying on
+    day of year averaged Mar 1 together with Feb 29, Mar 2 with Mar 1, and so
+    on through to the end of December.
     """
     accessor = times.dt if isinstance(times, pd.Series) else times
-    return accessor.day_of_year if period == DAILY else accessor.month
+    return accessor.strftime("%m-%d") if period == DAILY else accessor.month
 
 
 def _period_dates(periods: pd.Series, period: str, display_year: int) -> pd.Series:
     """Map group keys back onto timestamps within the year being displayed."""
     if period == DAILY:
-        start = pd.Timestamp(year=display_year, month=1, day=1)
-        return start + pd.to_timedelta(periods - 1, unit="D")
+        # Feb 29 has nowhere to land in a non-leap display year; coerced to NaT
+        # here and dropped by _with_period_dates.
+        return pd.to_datetime(
+            f"{display_year}-" + periods.astype(str),
+            format="%Y-%m-%d",
+            errors="coerce",
+        )
 
     months = periods.astype(int).astype(str).str.zfill(2)
     return pd.to_datetime(f"{display_year}-" + months + "-01", format="%Y-%m-%d")
+
+
+def _with_period_dates(
+    frame: pd.DataFrame,
+    period: str,
+    display_year: int,
+) -> pd.DataFrame:
+    """Add the display-year time column, dropping a leap day it cannot hold.
+
+    Anything other than Feb 29 failing to map is a bug rather than a calendar
+    quirk, so it raises instead of being quietly dropped.
+    """
+    column = time_column(period)
+    frame[column] = _period_dates(frame[_PERIOD], period, display_year)
+
+    unplaced = frame[column].isna()
+    if unplaced.any():
+        unexpected = frame.loc[unplaced, _PERIOD].ne(_LEAP_DAY)
+        if unexpected.any():
+            keys = frame.loc[unplaced, _PERIOD][unexpected].tolist()
+            msg = f"Could not place period keys {keys} in {display_year}"
+            raise ValueError(msg)
+        frame = frame[~unplaced]
+
+    return frame.reset_index(drop=True)
 
 
 def period_means(df: pd.DataFrame, column: str, period: str) -> pd.DataFrame:
@@ -127,6 +165,9 @@ def climatology(
     Returns canonical column names -- the time column plus ``mean``, ``max``,
     ``min``, ``min_date`` and ``max_date`` -- leaving the caller to relabel them
     for display.
+
+    A Feb 29 climatology is computed from the leap years in range but only
+    plotted when the display year can hold it.
     """
     display_year = int(display_year)
     keys = _period_keys(means_filtered.index, period).rename(_PERIOD)
@@ -137,14 +178,14 @@ def climatology(
         .reset_index()
     )
 
-    column = time_column(period)
-    clim[column] = _period_dates(clim[_PERIOD], period, display_year)
+    clim = _with_period_dates(clim, period, display_year)
 
     for name, source in (("min_date", "idxmin"), ("max_date", "idxmax")):
         clim[name] = pd.to_datetime(clim[source]).dt.date
 
+    column = time_column(period)
     ordered = [column, "mean", "max", "min", "min_date", "max_date"]
-    return clim[ordered].reset_index(drop=True)
+    return clim[ordered]
 
 
 def year_series(
@@ -165,6 +206,5 @@ def year_series(
     keys = _period_keys(in_year[TIME_COLUMN], period).rename(_PERIOD)
     means = in_year[column].groupby(keys).mean().rename("mean").reset_index()
 
-    column_name = time_column(period)
-    means[column_name] = _period_dates(means[_PERIOD], period, display_year)
-    return means[[column_name, "mean"]]
+    means = _with_period_dates(means, period, display_year)
+    return means[[time_column(period), "mean"]]

--- a/tests/unit/test_climatology_core.py
+++ b/tests/unit/test_climatology_core.py
@@ -163,6 +163,73 @@ def test_climatology_averages_the_same_calendar_day_across_years():
     assert march_first["min_date"].item() == datetime.date(2021, 3, 1)
 
 
+def leap_and_non_leap_years() -> pd.DataFrame:
+    """2019 (365 days) and 2020 (366), so day-of-year keys disagree after Feb."""
+    return pd.concat(
+        [observations("2019-01-01", 365), observations("2020-01-01", 366)],
+        ignore_index=True,
+    )
+
+
+def test_climatology_aligns_calendar_days_across_a_leap_year():
+    """Keyed on day of year, Mar 1 (day 60 in 2019) averaged with Feb 29 (day 60
+    in 2020), and everything after it was off by a day for the rest of the year.
+    """
+    means = core.period_means(leap_and_non_leap_years(), COLUMN, core.DAILY)
+    filtered = core.filter_means(means, threshold=0, start_year=2019, end_year=2020)
+
+    clim = core.climatology(filtered, core.DAILY, display_year=2021)
+
+    for stamp, expected in (
+        ("2021-03-01", 301.0),
+        ("2021-03-02", 302.0),
+        ("2021-12-31", 1231.0),
+    ):
+        row = clim[clim[core.TIME_COLUMN] == pd.Timestamp(stamp)]
+        assert row["mean"].item() == expected, f"{stamp} averaged the wrong day"
+
+
+def test_climatology_omits_the_leap_day_from_a_non_leap_display_year():
+    means = core.period_means(leap_and_non_leap_years(), COLUMN, core.DAILY)
+    filtered = core.filter_means(means, threshold=0, start_year=2019, end_year=2020)
+
+    clim = core.climatology(filtered, core.DAILY, display_year=2021)
+
+    assert len(clim) == 365
+    assert clim[core.TIME_COLUMN].dt.year.unique().tolist() == [2021]
+
+
+def test_climatology_keeps_the_leap_day_for_a_leap_display_year():
+    means = core.period_means(leap_and_non_leap_years(), COLUMN, core.DAILY)
+    filtered = core.filter_means(means, threshold=0, start_year=2019, end_year=2020)
+
+    clim = core.climatology(filtered, core.DAILY, display_year=2020)
+
+    assert len(clim) == 366
+    leap_day = clim[clim[core.TIME_COLUMN] == pd.Timestamp("2020-02-29")]
+    assert leap_day["mean"].item() == 229.0
+
+
+def test_climatology_never_maps_a_day_outside_the_display_year():
+    """Day-of-year keys ran to 366, and day 366 of a non-leap display year is
+    Jan 1 of the year after it."""
+    means = core.period_means(leap_and_non_leap_years(), COLUMN, core.DAILY)
+    filtered = core.filter_means(means, threshold=0, start_year=2019, end_year=2020)
+
+    clim = core.climatology(filtered, core.DAILY, display_year=2021)
+
+    assert clim[core.TIME_COLUMN].max() == pd.Timestamp("2021-12-31")
+
+
+def test_year_series_keeps_the_leap_day_of_a_leap_year():
+    df = leap_and_non_leap_years()
+
+    series = core.year_series(df, COLUMN, core.DAILY, 2020)
+
+    assert len(series) == 366
+    assert pd.Timestamp("2020-02-29") in set(series[core.TIME_COLUMN])
+
+
 def test_climatology_reports_the_year_that_set_each_extreme():
     warm = observations("2021-01-01", 2)
     cold = observations("2022-01-01", 2)


### PR DESCRIPTION
Stacked on #129. **This one changes published numbers**, which is why it is on its own.

## The bug

The daily climatology grouped on `means_filtered.index.day_of_year`. Day 60 is Feb 29 in a leap year and Mar 1 in every other one, so any climatology range spanning a leap year averaged:

| Day of year | Non-leap years contribute | Leap years contribute |
| --- | --- | --- |
| 60 | Mar 1 | Feb 29 |
| 61 | Mar 2 | Mar 1 |
| … | … | … |
| 365 | Dec 31 | Dec 30 |
| 366 | *(nothing)* | Dec 31 |

So for ten months of the year, every daily mean, min and max mixed two different calendar days, and the "year that set the max" dates in the table pointed at the neighbouring day. Every climatology on the site spans a leap year, so this affects all of them.

A second symptom: day-of-year keys ran to 366 and were mapped back with `Jan 1 + (day - 1)`, so in a non-leap display year day 366 landed on **Jan 1 of the following year**. Confirmed against live data before this change -- the 2026 daily climatology returned 366 rows with a point plotted at 2027-01-01.

## The fix

Key on the calendar month and day (`%m-%d`) instead. Feb 29 is still averaged from whichever leap years are in range, and is plotted when the display year can hold it and dropped when it cannot. Anything *other* than Feb 29 failing to map raises rather than being quietly dropped, so a real bug here cannot hide as a calendar quirk.

## Effect on the numbers

For any range spanning a leap year, daily means from Mar 1 onward shift by one calendar day. They were wrong before and are right now, but the values on the site will change, and a Feb 29 point appears in leap display years.

Monthly is unaffected.

## Verified

- 45 unit tests. New cases cover a 2019+2020 range asserting Mar 1, Mar 2 and Dec 31 each average only their own calendar day; the leap day being kept for a leap display year and dropped for a non-leap one; and that nothing maps outside the display year.
- Against live data (2015-2026, daily): display 2024 → 366 rows including Feb 29; display 2025 and 2026 → 365 rows, no Feb 29, max Dec 31 of the display year. Previously 2026 gave 366 rows ending in 2027.
- Full Playwright suite locally: 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)