### PR TITLE
Month-named axis, non-zero y scale, lines that break at gaps

### DIFF
--- a/climatology.py
+++ b/climatology.py
@@ -366,13 +366,25 @@ def _(
 
 
 @app.cell
-def _(clim_df, clim_tooltip, max_range_name, min_range_name, time_col):
+def _():
+    # Month names rather than the default, which leads with the year, and one
+    # tick per month so no month is labelled twice. The year is in the chart
+    # title. Every layer gets this same object, the logo included -- layered
+    # charts merge their axes, and two definitions is one too many.
+    time_axis = alt.Axis(format="%b", tickCount="month")
+    return (time_axis,)
+
+
+@app.cell
+def _(clim_df, clim_tooltip, max_range_name, min_range_name, time_axis, time_col):
     area = (
         alt.Chart(clim_df)
         .mark_area(color="yellow", opacity=0.5)
         .encode(
-            alt.X(time_col, type="temporal"),
-            alt.Y(min_range_name),
+            alt.X(time_col, type="temporal", axis=time_axis),
+            # Barometric pressure varies by a fraction of a percent, so a
+            # zero-anchored axis flattens it into a straight line.
+            alt.Y(min_range_name).scale(zero=False),
             alt.Y2(max_range_name),
             tooltip=clim_tooltip,
         )
@@ -381,13 +393,13 @@ def _(clim_df, clim_tooltip, max_range_name, min_range_name, time_col):
 
 
 @app.cell
-def _(clim_df, clim_tooltip, mean_range_name, time_col):
+def _(clim_df, clim_tooltip, mean_range_name, time_axis, time_col):
     mean = (
         alt.Chart(clim_df)
         .mark_line()
         .encode(
-            alt.X(time_col, type="temporal"),
-            alt.Y(mean_range_name),
+            alt.X(time_col, type="temporal", axis=time_axis),
+            alt.Y(mean_range_name).scale(zero=False),
             tooltip=clim_tooltip,
         )
     )
@@ -408,15 +420,20 @@ def _(average_period_dropdown, column, df_no_index, year_dropdown):
 
 
 @app.cell
-def _(df_year, time_col, time_format, ts, year_dropdown):
+def _(df_year, time_axis, time_col, time_format, ts, year_dropdown):
     _y_title = f"{ts['data_type']['long_name']} ({ts['data_type']['units']})"
 
+    # Points and a connecting line. year_series lays the means over every period
+    # of the year, so a gap in the data is a null and Vega breaks the line there
+    # rather than drawing across it.
     line = (
         alt.Chart(df_year)
-        .mark_point(color="red")
+        # point=True would take the default colour, leaving blue dots on a red
+        # line, so the overlay has to be coloured explicitly.
+        .mark_line(point=alt.OverlayMarkDef(color="red"), color="red")
         .encode(
-            alt.X(time_col, type="temporal"),
-            alt.Y("mean").title(_y_title),
+            alt.X(time_col, type="temporal", axis=time_axis),
+            alt.Y("mean").title(_y_title).scale(zero=False),
             tooltip=[
                 alt.Tooltip(field=time_col, type="temporal", format=time_format),
                 alt.Tooltip(
@@ -437,6 +454,7 @@ def _(
     end_year_dropdown,
     platform,
     start_year_dropdown,
+    time_axis,
     time_col,
     ts,
     year_dropdown,
@@ -445,6 +463,7 @@ def _(
         clim_df[time_col].max(),
         f"{ts['app_name']} at {platform['id']} for {start_year_dropdown.value} thru {max([end_year_dropdown.value, year_dropdown.value])}",
         time_col=time_col,
+        axis=time_axis,
     )
     return (logo,)
 

--- a/climatology_core.py
+++ b/climatology_core.py
@@ -188,17 +188,28 @@ def climatology(
     return clim[ordered]
 
 
+def _every_period_of(period: str, display_year: int) -> pd.DatetimeIndex:
+    """Every day or month of the year, so a series can be laid over all of it."""
+    if period == DAILY:
+        return pd.date_range(f"{display_year}-01-01", f"{display_year}-12-31", freq="D")
+    return pd.date_range(f"{display_year}-01-01", periods=12, freq="MS")
+
+
 def year_series(
     df: pd.DataFrame,
     column: str,
     period: str,
     display_year: str | int,
 ) -> pd.DataFrame:
-    """Daily or monthly means of ``column`` for a single year.
+    """Daily or monthly means of ``column`` for a single year, gaps included.
 
     Selected with ``.dt.year`` rather than string bounds: the comparison this
     replaces was exclusive at both ends, so an observation landing exactly on
     midnight, Jan 1 was dropped.
+
+    Laid over every period of the year, so periods without observations are
+    present as NaN rather than missing. That is what lets the plotted line break
+    at a data gap instead of drawing straight through it.
     """
     display_year = int(display_year)
     in_year = df[df[TIME_COLUMN].dt.year == display_year]
@@ -207,4 +218,11 @@ def year_series(
     means = in_year[column].groupby(keys).mean().rename("mean").reset_index()
 
     means = _with_period_dates(means, period, display_year)
-    return means[[time_column(period), "mean"]]
+
+    column_name = time_column(period)
+    return (
+        means.set_index(column_name)["mean"]
+        .reindex(_every_period_of(period, display_year))
+        .rename_axis(column_name)
+        .reset_index()
+    )

--- a/common.py
+++ b/common.py
@@ -303,14 +303,14 @@ def neracoos_logo(
     max_time,
     title: str,
     time_col: str = "time (UTC)",
-    axis_format: str | None = None,
+    axis=None,
 ):
     """Render the NERACOOS logo at the top right place on a plot.
 
     ``max_time`` should be the largest time in the chart being layered onto, so
-    that the logo sits at its right edge. ``axis_format`` has to match whatever
-    the other layers use: layered charts merge their axes, so leaving it unset
-    here would let this layer's default formatting win.
+    that the logo sits at its right edge. Pass the same ``axis`` the other
+    layers use: layered charts merge their axes, and leaving this one to its
+    defaults gives Vega two different definitions to reconcile.
     """
     try:
         _image_df = pd.DataFrame(
@@ -346,7 +346,7 @@ def neracoos_logo(
             x=alt.X(
                 time_col,
                 type="temporal",
-                axis=alt.Axis(format=axis_format) if axis_format else alt.Undefined,
+                axis=axis if axis is not None else alt.Undefined,
             ),
             y=alt.value(0),
             url="image",

--- a/tests/unit/test_climatology_core.py
+++ b/tests/unit/test_climatology_core.py
@@ -266,8 +266,46 @@ def test_year_series_includes_an_observation_at_midnight_january_first():
 
     series = core.year_series(df, COLUMN, core.DAILY, 2024)
 
+    jan_first = series[series[core.TIME_COLUMN] == pd.Timestamp("2024-01-01")]
+    assert jan_first["mean"].item() == 101.0
+
+
+def test_year_series_covers_every_period_of_the_year():
+    """Laid over the whole year so a gap is a null the chart can break at."""
+    df = pd.concat(
+        [observations("2024-01-01", 10), observations("2024-03-01", 10)],
+        ignore_index=True,
+    )
+
+    series = core.year_series(df, COLUMN, core.DAILY, 2024)
+
+    assert len(series) == 366
     assert series[core.TIME_COLUMN].min() == pd.Timestamp("2024-01-01")
-    assert len(series) == 2
+    assert series[core.TIME_COLUMN].max() == pd.Timestamp("2024-12-31")
+
+
+def test_year_series_leaves_gaps_as_nulls():
+    df = pd.concat(
+        [observations("2024-01-01", 10), observations("2024-03-01", 10)],
+        ignore_index=True,
+    )
+
+    series = core.year_series(df, COLUMN, core.DAILY, 2024)
+    observed = series.set_index(core.TIME_COLUMN)["mean"]
+
+    assert observed[pd.Timestamp("2024-01-05")] == 105.0
+    assert pd.isna(observed[pd.Timestamp("2024-02-05")])
+    assert observed[pd.Timestamp("2024-03-05")] == 305.0
+    assert observed.notna().sum() == 20
+
+
+def test_year_series_monthly_covers_twelve_months():
+    df = observations("2024-01-01", 40)
+
+    series = core.year_series(df, COLUMN, core.MONTHLY, 2024)
+
+    assert len(series) == 12
+    assert series["mean"].notna().sum() == 2
 
 
 def test_year_series_only_covers_the_requested_year():


### PR DESCRIPTION
Stacked on #132. Three more chart items from #38 and #21.

## 1. X axis reads Jan…Dec

Vega labels the first tick of a temporal axis with the year, so the axis read `2024, Feb, Mar, …`. It is now one tick per month formatted as the month name; the year is already in the chart title. — #38 *"X-axis labels start with year but January"*

## 2. Y axis no longer anchored at zero

Quantitative scales default to including zero, which flattens anything with a small relative range. Barometric pressure varies by a fraction of a percent around 1013 mbar, so the whole signal was a straight line — the exact example in the issue. `zero=False` on all three layers.

## 3. Points **and** lines, breaking at gaps

The running series was `mark_point` only, because a line drew straight through missing data. `year_series` now lays the means over every day (or month) of the year, so a period with no observations is a null rather than an absent row — and Vega breaks a line at nulls. `mark_line(point=...)` then gives points plus a connecting line that stops at each gap, like the old tool. — #21 comment and #38 *"ideally we have points and lines like the current tool - still need it to break at data gaps"*

Done with nulls rather than `ImputeTransform` (suggested in the #21 comment): once the series is laid over the full year its gaps are already explicit, so there is nothing to impute.

The point overlay is coloured explicitly — `point=True` takes the default colour, which left blue dots on a red line.

## Verified visually

Screenshotted the rendered canvas against live data:

- **Barometric pressure, Western Maine Shelf** — axis Jan…Dec, y axis 980–1050 instead of 0–1050, variation legible instead of flat.
- **Air temperature, 2020** — 328 observed days and 38 gaps out of 366; the line breaks at the gaps and keeps its (red) points.

## Also

`common.neracoos_logo` takes the `axis` its sibling layers use instead of a bare format string. Layered charts merge their axes, and letting the logo layer keep its defaults gave Vega two definitions to reconcile.

48 unit tests (three new: full-year coverage, gaps as nulls, the monthly case). Full Playwright suite: 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)