### PR TITLE
Show the monthly data table by month, not by timestamp

### DIFF
--- a/climatology.py
+++ b/climatology.py
@@ -417,6 +417,8 @@ def _(average_period_dropdown, clim_df, df_year, time_col, year_dropdown):
 
     if _period == core.DAILY:
         df_combined[time_col] = df_combined[time_col].dt.date
+    else:
+        df_combined[time_col] = df_combined[time_col].dt.strftime("%Y-%m")
 
     # Named rather than sliced by position: the slicing this replaces dropped
     # the mean column outright from the monthly table.


### PR DESCRIPTION
Independent of the other open PRs — based on `main`.

The daily data table already rendered date-only, but the monthly one showed a full timestamp for the first of the month: `2007-02-01T00:00:00.000` for what is a February average. It now reads `2007-02`.

Closes #38 — *"Data table - can we date only in the date/time format? It will tidy up the table as well. --> 2007-02-20T00:00:00.000"*.

The monthly table was unreachable until #129 (selecting Monthly raised `KeyError` before that), which is why this went unnoticed.

## Verified

Against live data, reproducing what the table cell does for both periods:

```
--- Daily ---
[datetime.date(2026, 1, 1), datetime.date(2026, 1, 2), ...]
--- Monthly ---
['2026-01', '2026-02', '2026-03', '2026-04', '2026-05']
```

Daily is untouched. 54 unit tests and the full 18-test Playwright suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)