### PR TITLE
Keep the threshold when another selection changes

### DIFF
--- a/climatology.py
+++ b/climatology.py
@@ -213,7 +213,7 @@ def _(average_period_dropdown, end_year_dropdown, start_year_dropdown):
 
 
 @app.cell
-def _(average_period_dropdown, column, df_no_index):
+def _(average_period_dropdown, column, df_no_index, query_params):
     _period = average_period_dropdown.value
     means = core.period_means(df_no_index, column, _period)
 
@@ -226,12 +226,24 @@ def _(average_period_dropdown, column, df_no_index):
             y="count()",
         )
     )
+    _stop = int(means["count"].max())
+    _key = f"threshold_{_period.lower()}"
     threshold = mo.ui.number(
         start=0,
-        stop=int(means["count"].max()),
+        stop=_stop,
         step=1,
-        value=core.threshold_default(_period),
+        value=common.query_param_int(
+            query_params,
+            _key,
+            fallback=core.threshold_default(_period),
+            maximum=_stop,
+        ),
         label=f"Minimum number of {'daily' if _period == core.DAILY else 'monthly'} values",
+        # Guarded like the dropdowns: emptying the field hands the callback
+        # None, and int(None) is a TypeError.
+        on_change=lambda value: (
+            query_params.set(_key, str(int(value))) if value is not None else None
+        ),
     )
 
     mo.accordion(

--- a/common.py
+++ b/common.py
@@ -121,6 +121,26 @@ def query_param_default(query_params, key: str, options, fallback=None):
     return fallback
 
 
+def query_param_int(query_params, key, *, fallback, minimum=0, maximum=None):
+    """A query parameter as an int, clamped into range, or ``fallback``.
+
+    Widgets like ``mo.ui.number`` reject a value outside their own
+    ``start``/``stop`` range, so both a stored value and ``fallback`` are
+    clamped here -- a sparse dataset can have a maximum observation count
+    below a threshold's usual default.
+    """
+    value = query_params.get(key)
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        result = fallback
+
+    result = max(result, minimum)
+    if maximum is not None:
+        result = min(result, maximum)
+    return int(result)
+
+
 def erddap_client(ts: dict):
     """A configured erddapy client for a Buoy Barn timeseries."""
     import erddapy

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -126,6 +126,52 @@ def test_query_param_default_falls_back_when_unset():
     assert common.query_param_default(FakeQueryParams(), "year", ["2024"]) is None
 
 
+def test_query_param_int_accepts_a_valid_stored_value():
+    params = FakeQueryParams(threshold_daily="5")
+
+    assert common.query_param_int(params, "threshold_daily", fallback=18) == 5
+
+
+def test_query_param_int_falls_back_when_missing():
+    assert (
+        common.query_param_int(FakeQueryParams(), "threshold_daily", fallback=18) == 18
+    )
+
+
+def test_query_param_int_falls_back_when_not_numeric():
+    params = FakeQueryParams(threshold_daily="not-a-number")
+
+    assert common.query_param_int(params, "threshold_daily", fallback=18) == 18
+
+
+def test_query_param_int_clamps_a_stored_value_above_maximum():
+    params = FakeQueryParams(threshold_daily="100")
+
+    assert (
+        common.query_param_int(params, "threshold_daily", fallback=18, maximum=20) == 20
+    )
+
+
+def test_query_param_int_clamps_a_stored_value_below_minimum():
+    params = FakeQueryParams(threshold_daily="-5")
+
+    assert (
+        common.query_param_int(params, "threshold_daily", fallback=18, minimum=0) == 0
+    )
+
+
+def test_query_param_int_clamps_a_fallback_above_maximum():
+    assert (
+        common.query_param_int(
+            FakeQueryParams(),
+            "threshold_daily",
+            fallback=18,
+            maximum=10,
+        )
+        == 10
+    )
+
+
 def test_resample_to_budget_passes_small_frames_through_untouched():
     df = erddap_frame(10)
 


### PR DESCRIPTION
Independent of the other open PRs — based on `main`.

## The bug

From a comment on #21:

> Threshold config resets to default if you change anything in the select options (year, variable, climatology range). Example: UNH CO2 buoy water temp was measured every three hours from 2008 to 2021, then changed to 10 minutes. When you set the initial threshold to 5 the climatology looks good but it resets if you change years for time series or variable.

The cause is structural: the `mo.ui.number` widget is built in the same cell that computes the period means, so *any* upstream change rebuilds the widget from scratch and it reverts to the default (18 daily, 20 monthly). Every other control on the page already survives that by round-tripping through the URL query params — the threshold now does too.

The key is period-specific (`threshold_daily`, `threshold_monthly`) because the two defaults mean different things: 18 is 3/4 of hourly observations in a day, 20 is 2/3 of the days in a month. Sharing one key would carry a nonsensical number across a period switch.

## On per-dataset defaults

The same comment asks for defaults *per dataset* for exception datasets like the CO2 buoy. That needs somewhere to store them — most naturally a field on the Buoy Barn timeseries the app can read — so it is not in here; it is tracked in #136. What this does give you is a shareable link that carries a working threshold, which covers the practical case of pointing someone at a good view of an awkward dataset.

## `common.query_param_int`

New helper, unit tested with six cases. It clamps what it reads **including the fallback**, which fixes a latent problem: a sparse dataset can have a maximum observation count below 18, and `mo.ui.number` rejects a `value` above its own `stop`. The `on_change` is guarded for `None` the same way the dropdowns are, since emptying the field hands the callback `None` and `int(None)` raises.

## Verified in a browser

Loaded `/climatology/?platform=Western+Maine+Shelf&ts=Air+Temperature&threshold_daily=5`, expanded the Threshold configuration accordion, and read the input back:

```
via label: 5
```

So the widget takes 5 from the URL rather than resetting to 18. 54 unit tests (6 new) and the full 18-test Playwright suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)