### PR TITLE
Report the climatology and the selected year in one hover

### DIFF
--- a/climatology.py
+++ b/climatology.py
@@ -351,11 +351,13 @@ def _(
     min_range_name,
     time_col,
     time_format,
+    year_column,
 ):
     # field= and type= rather than altair's shorthand, because these names carry
     # the climatology range in parentheses.
     clim_tooltip = [
         alt.Tooltip(field=time_col, type="temporal", format=time_format),
+        alt.Tooltip(field=year_column, type="quantitative", format=".2f"),
         alt.Tooltip(field=mean_range_name, type="quantitative", format=".2f"),
         alt.Tooltip(field=min_range_name, type="quantitative", format=".2f"),
         alt.Tooltip(field=min_date_name, type="nominal"),
@@ -376,9 +378,9 @@ def _():
 
 
 @app.cell
-def _(clim_df, clim_tooltip, max_range_name, min_range_name, time_axis, time_col):
+def _(clim_tooltip, df_plot, max_range_name, min_range_name, time_axis, time_col):
     area = (
-        alt.Chart(clim_df)
+        alt.Chart(df_plot)
         .mark_area(color="yellow", opacity=0.5)
         .encode(
             alt.X(time_col, type="temporal", axis=time_axis),
@@ -393,9 +395,9 @@ def _(clim_df, clim_tooltip, max_range_name, min_range_name, time_axis, time_col
 
 
 @app.cell
-def _(clim_df, clim_tooltip, mean_range_name, time_axis, time_col):
+def _(clim_tooltip, df_plot, mean_range_name, time_axis, time_col):
     mean = (
-        alt.Chart(clim_df)
+        alt.Chart(df_plot)
         .mark_line()
         .encode(
             alt.X(time_col, type="temporal", axis=time_axis),
@@ -420,29 +422,47 @@ def _(average_period_dropdown, column, df_no_index, year_dropdown):
 
 
 @app.cell
-def _(df_year, time_axis, time_col, time_format, ts, year_dropdown):
+def _(average_period_dropdown, clim_df, df_year, time_col, year_dropdown):
+    year_column = (
+        f"{'Daily' if average_period_dropdown.value == core.DAILY else 'Monthly'} mean"
+        f" for {year_dropdown.value}"
+    )
+
+    # Every layer draws from one frame, so a single hover reports the
+    # climatology and the selected year together instead of whichever mark
+    # happens to be under the cursor.
+    #
+    # Outer, so neither side loses rows: the year keeps the empty periods that
+    # break its line at data gaps, and the climatology keeps any period the
+    # year has no observations for.
+    df_plot = (
+        clim_df.merge(
+            df_year.rename({"mean": year_column}, axis=1),
+            on=time_col,
+            how="outer",
+        )
+        .sort_values(time_col)
+        .reset_index(drop=True)
+    )
+    return df_plot, year_column
+
+
+@app.cell
+def _(clim_tooltip, df_plot, time_axis, time_col, ts, year_column):
     _y_title = f"{ts['data_type']['long_name']} ({ts['data_type']['units']})"
 
     # Points and a connecting line. year_series lays the means over every period
     # of the year, so a gap in the data is a null and Vega breaks the line there
     # rather than drawing across it.
     line = (
-        alt.Chart(df_year)
+        alt.Chart(df_plot)
         # point=True would take the default colour, leaving blue dots on a red
         # line, so the overlay has to be coloured explicitly.
         .mark_line(point=alt.OverlayMarkDef(color="red"), color="red")
         .encode(
             alt.X(time_col, type="temporal", axis=time_axis),
-            alt.Y("mean").title(_y_title).scale(zero=False),
-            tooltip=[
-                alt.Tooltip(field=time_col, type="temporal", format=time_format),
-                alt.Tooltip(
-                    field="mean",
-                    type="quantitative",
-                    format=".2f",
-                    title=f"{year_dropdown.value} mean",
-                ),
-            ],
+            alt.Y(year_column).title(_y_title).scale(zero=False),
+            tooltip=clim_tooltip,
         )
     )
     return (line,)


### PR DESCRIPTION
Stacked on #134. From your notes: *"show both the climatology values and the selected year in the tooltip at the same time"*.

## The problem

The climatology band and the selected year are separate chart layers, and #132 gave each its own tooltip. So a hover reported whichever mark was under the cursor — either the climatology mean/min/max for that day, or that year's value, never both. Confirmed in the browser before changing anything: hovering the red series gave only `Date / 2020 mean`, hovering the yellow band gave only the climatology fields.

## The change

All three layers now draw from one merged frame, so one hover reports everything:

```
Date                    Aug 20
Daily mean for 2020     18.26
Mean (2001 - 2025)      19.00
Min (2001 - 2025)       15.24
Min date                Aug 20, 2007
Max (2001 - 2025)       21.30
Max date                Aug 20, 2019
```

The merge is **outer** rather than left, so neither side loses rows: the year keeps the empty periods that #134 relies on to break its line at data gaps, and the climatology keeps any period the selected year has no observations for.

This is deliberately done without a `pivot` transform or a nearest-point selection layer. The data is already wide once merged, so there is nothing to pivot, and adding a selection parameter risks colliding with the ones `mo.ui.altair_chart` adds — the e2e suite asserts on `Duplicate signal name` for exactly that reason. The trade-off is that the hover still needs to be near a mark rather than anywhere in the plot at that x; in practice the yellow band covers most of the plot area, so this is not noticeable. Happy to add a rule layer if you want true anywhere-in-column hovering.

Side benefit: the three layers share one inlined dataset instead of two, so the vega spec carries less data.

## Verified

- Tooltip content read out of the live DOM (above), for two different hover positions.
- Chart screenshotted before and after — visually identical, so the merge changed the tooltip and nothing else: red points, gaps still breaking, Jan…Dec axis, non-zero y scale all intact.
- No page errors, and no `Duplicate signal name`.
- 54 unit tests, 18 e2e.

## Note on overlap

The data table cell still does its own merge of the same two frames, so there is a little duplication now. I left it alone on purpose: #148 touches that cell and is independent of this stack, and consolidating the two merges would have made them conflict. Worth a small follow-up once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #137.
