### PR TITLE
Add Sentry error monitoring, tracing, and the user-feedback widget

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -128,6 +128,7 @@ jobs:
         run: |
           docker run -d --name climatology-sentry -p 8081:8080 \
             -e SENTRY_DSN=https://e2e00000000000000000000000000000@o0.ingest.invalid/1 \
+            -e SENTRY_LOADER_URL=https://js.sentry-cdn.com/e2e00000000000000000000000000000.min.js \
             -e SENTRY_ENVIRONMENT=e2e \
             gmri/neracoos-climatology-py-dash:latest
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,6 +58,12 @@ jobs:
           context: .
           push: false
           tags: gmri/neracoos-climatology-py-dash:latest
+          # Baked in here rather than supplied at deploy time: the image is
+          # built once, in this job, and merely retagged when it is pushed
+          # later, so this is the only point the release is guaranteed to
+          # match the image contents.
+          build-args: |
+            SENTRY_RELEASE=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/image.tar
@@ -114,6 +120,17 @@ jobs:
           docker run -d --name climatology -p 8080:8080
           gmri/neracoos-climatology-py-dash:latest
 
+      - name: Run app container with a dummy Sentry DSN
+        # A second instance, on its own port, so the Sentry-specific checks in
+        # tests/e2e/test_sentry.py run against a configured server without the
+        # rest of the suite's DSN-less assertions (test_pages.py) running
+        # against one that has Sentry turned on.
+        run: |
+          docker run -d --name climatology-sentry -p 8081:8080 \
+            -e SENTRY_DSN=https://e2e00000000000000000000000000000@o0.ingest.invalid/1 \
+            -e SENTRY_ENVIRONMENT=e2e \
+            gmri/neracoos-climatology-py-dash:latest
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
@@ -131,15 +148,24 @@ jobs:
 
       - name: Wait for app to be ready
         run: |
-          for i in $(seq 1 60); do
-            curl -sf http://localhost:8080/health && exit 0
-            sleep 2
+          for port in 8080 8081; do
+            for i in $(seq 1 60); do
+              curl -sf http://localhost:$port/health && break
+              sleep 2
+              if [ "$i" -eq 60 ]; then
+                echo "App container on port $port did not become ready within 120 seconds" >&2
+                exit 1
+              fi
+            done
           done
-          echo "App container did not become ready within 120 seconds" >&2
-          exit 1
 
       - name: Run end-to-end tests
-        run: E2E_BASE_URL=http://localhost:8080 pixi run -e test e2e
+        # E2E_SENTRY_WIDGET is deliberately left unset -- that test loads the
+        # real Sentry SDK from its CDN, and CI stays off the network here.
+        run: |
+          E2E_BASE_URL=http://localhost:8080 \
+          E2E_SENTRY_BASE_URL=http://localhost:8081 \
+          pixi run -e test e2e
 
       - name: Show app container logs
         if: failure()
@@ -162,6 +188,7 @@ jobs:
             | tee test-results/container.log \
             | grep -vE '"GET [^"]*/(assets/[^"]*|public-files-sw\.js(\?[^"]*)?|health)( HTTP/[0-9.]+)?" 200 (OK|[0-9.]+)$' \
             || true
+          docker logs climatology-sentry > test-results/container-sentry.log 2>&1 || true
 
       - name: Upload test results
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ USER app_user
 
 ENV MARIMO_SKIP_UPDATE_CHECK=1
 
+# Baked in at build time rather than supplied at deploy time: the image is
+# built once (see the `build` job in .github/workflows/push.yml) and merely
+# retagged when it is pushed, so this is the only point at which the release
+# is guaranteed to match the image contents.
+ARG SENTRY_RELEASE=""
+ENV SENTRY_RELEASE=${SENTRY_RELEASE}
+
 CMD ["pixi", "run", "--frozen", "serve"]
 
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/README.md
+++ b/README.md
@@ -25,28 +25,37 @@ an already-running server or container instead of spawning one.
 Similarly, `E2E_SENTRY_BASE_URL` points the Sentry-specific tests
 (`tests/e2e/test_sentry.py`) at an already-running, Sentry-configured server
 instead of spawning one with a dummy DSN. `E2E_SENTRY_WIDGET=1` additionally
-opts in to the one test that loads the real Sentry SDK from its CDN (skipped
-by default, so CI stays off the network).
+opts in to the one test that loads the real Sentry SDK from its CDN (skipped by
+default, so CI stays off the network).
 
 ## Monitoring
 
 Errors, traces, and the user-feedback widget are provided by
-[Sentry](https://sentry.io) (`monitoring.py`). Everything is a no-op unless
-`SENTRY_DSN` is set -- local runs, the devcontainer, and CI all leave it unset,
-so none of them talk to Sentry or load any third-party script.
+[Sentry](https://sentry.io) (`monitoring.py`). Backend monitoring is a no-op
+unless `SENTRY_DSN` is set; the browser widget additionally needs
+`SENTRY_LOADER_URL`. Local runs, the devcontainer, and CI leave both unset, so
+none of them talk to Sentry or load any third-party script.
 
-| Env var | Effect |
-| --- | --- |
-| `SENTRY_DSN` | Turns monitoring on. Also read by the browser widget -- a DSN is public by design, so this is the same value on both sides. |
-| `SENTRY_ENVIRONMENT` | e.g. `production`, `staging`, a developer's name for local testing. |
-| `SENTRY_RELEASE` | Baked into the production image from the commit SHA (see the `build` job in `.github/workflows/push.yml` and the `Dockerfile`); set by hand for local testing. |
-| `SENTRY_TRACES_SAMPLE_RATE` | `0.0` (off) by default; `0.2` in production. |
+| Env var                     | Effect                                                                                                                                                                                                                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SENTRY_DSN`                | Turns backend monitoring on and gates the browser snippet (both are required for it to be injected).                                                                                                                                                                                                                |
+| `SENTRY_LOADER_URL`         | The URL from Sentry's Settings -> Loader Script page, e.g. `https://js.sentry-cdn.com/<key>.min.js`. That page shows it wrapped in a `<script src="...">` tag; either the bare URL or the whole tag works here. Has its own DSN baked in server-side, so it does not have to name the same project as `SENTRY_DSN`. |
+| `SENTRY_ENVIRONMENT`        | e.g. `production`, `staging`, a developer's name for local testing.                                                                                                                                                                                                                                                 |
+| `SENTRY_RELEASE`            | Baked into the production image from the commit SHA (see the `build` job in `.github/workflows/push.yml` and the `Dockerfile`); set by hand for local testing.                                                                                                                                                      |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.0` (off) by default; `0.2` in production.                                                                                                                                                                                                                                                                        |
 
-In production, `SENTRY_DSN` is supplied by a `climatology-sentry` Kubernetes
-Secret (see `k8s/deployment.yaml`), provisioned in the
-[`neracoos-aws-cd`](https://github.com/gulfofmaine/neracoos-aws-cd) repository.
+Because `SENTRY_LOADER_URL`'s DSN is baked in server-side rather than read from
+`SENTRY_DSN`, pointing `SENTRY_DSN` at a different (e.g. personal) project for
+local testing sends backend events there, while browser events still go to
+whichever project the loader is configured for -- set `SENTRY_LOADER_URL` to a
+personal project's loader too if you want both sides to match.
 
-To point a local run at a personal Sentry project:
+In production, `SENTRY_DSN` and `SENTRY_LOADER_URL` are supplied by a
+`climatology-sentry` Kubernetes Secret (see `k8s/deployment.yaml`), provisioned
+in the [`neracoos-aws-cd`](https://github.com/gulfofmaine/neracoos-aws-cd)
+repository.
+
+To point a local run's backend at a personal Sentry project:
 
 ```
 SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project> \

--- a/README.md
+++ b/README.md
@@ -21,3 +21,35 @@ app framework to allow rapid iteration and then a Streamlit-like experience.
 Set the `E2E_BASE_URL` environment variable (e.g.
 `E2E_BASE_URL=http://localhost:8080 pixi run -e test e2e`) to point the tests at
 an already-running server or container instead of spawning one.
+
+Similarly, `E2E_SENTRY_BASE_URL` points the Sentry-specific tests
+(`tests/e2e/test_sentry.py`) at an already-running, Sentry-configured server
+instead of spawning one with a dummy DSN. `E2E_SENTRY_WIDGET=1` additionally
+opts in to the one test that loads the real Sentry SDK from its CDN (skipped
+by default, so CI stays off the network).
+
+## Monitoring
+
+Errors, traces, and the user-feedback widget are provided by
+[Sentry](https://sentry.io) (`monitoring.py`). Everything is a no-op unless
+`SENTRY_DSN` is set -- local runs, the devcontainer, and CI all leave it unset,
+so none of them talk to Sentry or load any third-party script.
+
+| Env var | Effect |
+| --- | --- |
+| `SENTRY_DSN` | Turns monitoring on. Also read by the browser widget -- a DSN is public by design, so this is the same value on both sides. |
+| `SENTRY_ENVIRONMENT` | e.g. `production`, `staging`, a developer's name for local testing. |
+| `SENTRY_RELEASE` | Baked into the production image from the commit SHA (see the `build` job in `.github/workflows/push.yml` and the `Dockerfile`); set by hand for local testing. |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.0` (off) by default; `0.2` in production. |
+
+In production, `SENTRY_DSN` is supplied by a `climatology-sentry` Kubernetes
+Secret (see `k8s/deployment.yaml`), provisioned in the
+[`neracoos-aws-cd`](https://github.com/gulfofmaine/neracoos-aws-cd) repository.
+
+To point a local run at a personal Sentry project:
+
+```
+SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project> \
+SENTRY_ENVIRONMENT=local \
+pixi run serve
+```

--- a/app.py
+++ b/app.py
@@ -1,8 +1,19 @@
 import marimo
 from fastapi import FastAPI
 
+import monitoring
+
+# Before create_asgi_app()/FastAPI(): Sentry instruments Starlette by patching
+# middleware construction, so apps built before init are not traced. Run-mode
+# marimo kernels are threads of this process (marimo._session.managers.kernel),
+# so this one call also covers every notebook's cells. A no-op when
+# SENTRY_DSN is unset.
+monitoring.init_sentry()
+
 server = (
-    marimo.create_asgi_app()
+    # Injected before </head> of every notebook page; None unless SENTRY_DSN is
+    # set, so nothing third-party loads outside a configured deployment.
+    marimo.create_asgi_app(html_head=monitoring.html_head())
     .with_app(path="/", root="./root.py")
     .with_app(path="/by_platform", root="./by_platform.py")
     .with_app(path="/by_standard_name", root="./by_standard_name.py")

--- a/by_platform.py
+++ b/by_platform.py
@@ -93,6 +93,7 @@ def _(time_series_selector):
                         str(error),
                         title=f"Unable to load data for {_col_name}",
                         kind="error",
+                        sentry_event_id=error.sentry_event_id,
                     ),
                 )
     return loaded_ts, unit_ts

--- a/by_platform.py
+++ b/by_platform.py
@@ -12,11 +12,12 @@ with app.setup:
     import pandas as pd
 
     import common
+    import monitoring
 
 
 @app.cell
 def _():
-    common.set_defaults()
+    common.set_defaults(page="by_platform")
     common.sidebar_menu()
 
 
@@ -106,7 +107,12 @@ def _(loaded_ts):
                 _df = _df.loc[~_df.index.duplicated(keep="first")]
             _dfs.append(_df)
         df = pd.concat(_dfs, axis=1)
-    except ValueError:
+    except ValueError as error:
+        if _dfs:
+            # pd.concat([], axis=1) is the "nothing selected yet" case; a
+            # ValueError with data present is a genuine bug wearing the same
+            # message, and would otherwise never reach Sentry.
+            monitoring.report(error, where="by_platform.concat", level="error")
         mo.stop(
             True,
             common.admonition(

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -12,6 +12,7 @@ with app.setup:
     import pandas as pd
 
     import common
+    import monitoring
 
 
 @app.cell
@@ -27,7 +28,7 @@ def _():
 
 @app.cell
 def _():
-    common.set_defaults()
+    common.set_defaults(page="by_standard_name")
     common.sidebar_menu()
 
 
@@ -167,7 +168,16 @@ def _(platform_options, selected_ts_keys, unit):
                 columns={"variable": "Timeseries", "value": unit},
             )
             wide_melted = wide_melted.set_index("time (UTC)")
-    except ValueError:
+    except ValueError as error:
+        if _wide_dfs:
+            # pd.concat([], axis=1) is the "nothing selected yet" case; a
+            # ValueError with data present is a genuine bug wearing the same
+            # message, and would otherwise never reach Sentry.
+            monitoring.report(
+                error,
+                where="by_standard_name.concat",
+                level="error",
+            )
         mo.stop(
             True,
             common.admonition(

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -155,6 +155,7 @@ def _(platform_options, selected_ts_keys, unit):
                             str(error),
                             title=f"Unable to load data for {_ts_name}",
                             kind="error",
+                            sentry_event_id=error.sentry_event_id,
                         ),
                     )
                     continue

--- a/calculate_datums.py
+++ b/calculate_datums.py
@@ -101,24 +101,42 @@ def _(common, dataset_id, erddapy, mo, monitoring, use_qartod):
     e.variables = ["time", "latitude", "longitude", "navd88_meters"]
     e.constraints = {"qartod_qc_rollup=": 1} if use_qartod.value else {}
     e.requests_kwargs = {"timeout": common.ERDDAP_TIMEOUT}
-    try:
-        with mo.status.spinner("Loading data..."):
+    with (
+        mo.status.spinner("Loading data..."),
+        monitoring.operation(
+            "calculate_datums.load",
+            op="http.client",
+            dataset=dataset_id,
+        ),
+    ):
+        try:
             df = e.to_pandas(index_col="time (UTC)", parse_dates=True).dropna()
-    except Exception as error:
-        # This is a raw erddapy load with no ErddapLoadError wrapper, unlike
-        # common.load_ts_from_erddap -- report it directly, since it otherwise
-        # never reaches Sentry. Stop rather than appending: the cell used to
-        # fall through to `return (df,)` with df unbound, so a load failure
-        # surfaced as a NameError from a cell several steps downstream.
-        monitoring.report(error, where="calculate_datums.load", level="error")
-        mo.stop(
-            True,
-            common.admonition(
-                f"Error loading data: {error}",
-                title="Data Load Error",
-                kind="error",
-            ),
-        )
+        except Exception as error:
+            # This is a raw erddapy load with no ErddapLoadError wrapper,
+            # unlike common.load_ts_from_erddap -- report it directly, since
+            # it otherwise never reaches Sentry. Stop rather than appending:
+            # the cell used to fall through to `return (df,)` with df
+            # unbound, so a load failure surfaced as a NameError from a cell
+            # several steps downstream.
+            #
+            # Reported from inside the operation() span (not after this
+            # `with` exits): capture_exception() only picks up trace context
+            # that is still current, and the span's own __exit__ would have
+            # already torn that down by the time an outer `except` ran.
+            event_id = monitoring.report(
+                error,
+                where="calculate_datums.load",
+                level="error",
+            )
+            mo.stop(
+                True,
+                common.admonition(
+                    f"Error loading data: {error}",
+                    title="Data Load Error",
+                    kind="error",
+                    sentry_event_id=event_id,
+                ),
+            )
     return (df,)
 
 
@@ -142,37 +160,43 @@ def _(df):
 
 @app.cell
 def _(common, df_reset, latitude, longitude, mo, monitoring, tadc):
-    try:
-        with (
-            mo.redirect_stderr(),
-            mo.redirect_stdout(),
-            monitoring.operation(
-                "tadc.run",
-                op="compute",
-                rows=len(df_reset),
-            ),
-        ):
+    with (
+        mo.redirect_stderr(),
+        mo.redirect_stdout(),
+        monitoring.operation(
+            "tadc.run",
+            op="compute",
+            rows=len(df_reset),
+        ),
+    ):
+        try:
             out = tadc.run(
                 data=df_reset,
                 Subordinate_Lat=latitude,
                 Subordinate_Lon=longitude,
             )
-    except Exception as error:
-        # tadc is a third-party numerical library running on user-selected
-        # data -- exactly the kind of failure we want visibility into.
-        monitoring.report(
-            error,
-            where="calculate_datums.tadc_run",
-            level="error",
-        )
-        mo.stop(
-            True,
-            common.admonition(
-                kind="error",
-                title="Error",
-                content=f"Error trying to calculate datums: {error}",
-            ),
-        )
+        except Exception as error:
+            # tadc is a third-party numerical library running on
+            # user-selected data -- exactly the kind of failure we want
+            # visibility into. Reported from inside the operation() span (not
+            # after this `with` exits): capture_exception() only picks up
+            # trace context that is still current, and the span's own
+            # __exit__ would have already torn that down by the time an
+            # outer `except` ran.
+            event_id = monitoring.report(
+                error,
+                where="calculate_datums.tadc_run",
+                level="error",
+            )
+            mo.stop(
+                True,
+                common.admonition(
+                    kind="error",
+                    title="Error",
+                    content=f"Error trying to calculate datums: {error}",
+                    sentry_event_id=event_id,
+                ),
+            )
     return (out,)
 
 

--- a/calculate_datums.py
+++ b/calculate_datums.py
@@ -14,8 +14,9 @@ def _():
     import tadc
 
     import common
+    import monitoring
 
-    return OrderedDict, common, erddapy, mo, pd, tadc
+    return OrderedDict, common, erddapy, mo, monitoring, pd, tadc
 
 
 @app.cell
@@ -33,7 +34,7 @@ def _(mo):
 
 @app.cell
 def _(common):
-    common.set_defaults()
+    common.set_defaults(page="calculate_datums")
     common.sidebar_menu()
 
 
@@ -82,7 +83,7 @@ def _(dataset_dropdown):
 
 
 @app.cell
-def _(common, dataset_id, erddapy, mo, use_qartod):
+def _(common, dataset_id, erddapy, mo, monitoring, use_qartod):
     mo.stop(
         dataset_id is None,
         common.admonition(
@@ -104,9 +105,12 @@ def _(common, dataset_id, erddapy, mo, use_qartod):
         with mo.status.spinner("Loading data..."):
             df = e.to_pandas(index_col="time (UTC)", parse_dates=True).dropna()
     except Exception as error:
-        # Stop rather than appending: the cell used to fall through to
-        # `return (df,)` with df unbound, so a load failure surfaced as a
-        # NameError from a cell several steps downstream.
+        # This is a raw erddapy load with no ErddapLoadError wrapper, unlike
+        # common.load_ts_from_erddap -- report it directly, since it otherwise
+        # never reaches Sentry. Stop rather than appending: the cell used to
+        # fall through to `return (df,)` with df unbound, so a load failure
+        # surfaced as a NameError from a cell several steps downstream.
+        monitoring.report(error, where="calculate_datums.load", level="error")
         mo.stop(
             True,
             common.admonition(
@@ -137,15 +141,30 @@ def _(df):
 
 
 @app.cell
-def _(common, df_reset, latitude, longitude, mo, tadc):
+def _(common, df_reset, latitude, longitude, mo, monitoring, tadc):
     try:
-        with mo.redirect_stderr(), mo.redirect_stdout():
+        with (
+            mo.redirect_stderr(),
+            mo.redirect_stdout(),
+            monitoring.operation(
+                "tadc.run",
+                op="compute",
+                rows=len(df_reset),
+            ),
+        ):
             out = tadc.run(
                 data=df_reset,
                 Subordinate_Lat=latitude,
                 Subordinate_Lon=longitude,
             )
     except Exception as error:
+        # tadc is a third-party numerical library running on user-selected
+        # data -- exactly the kind of failure we want visibility into.
+        monitoring.report(
+            error,
+            where="calculate_datums.tadc_run",
+            level="error",
+        )
         mo.stop(
             True,
             common.admonition(

--- a/calculate_datums.py
+++ b/calculate_datums.py
@@ -123,7 +123,7 @@ def _(common, dataset_id, erddapy, mo, monitoring, use_qartod):
             # `with` exits): capture_exception() only picks up trace context
             # that is still current, and the span's own __exit__ would have
             # already torn that down by the time an outer `except` ran.
-            event_id = monitoring.report(
+            _event_id = monitoring.report(
                 error,
                 where="calculate_datums.load",
                 level="error",
@@ -134,7 +134,7 @@ def _(common, dataset_id, erddapy, mo, monitoring, use_qartod):
                     f"Error loading data: {error}",
                     title="Data Load Error",
                     kind="error",
-                    sentry_event_id=event_id,
+                    sentry_event_id=_event_id,
                 ),
             )
     return (df,)
@@ -183,7 +183,7 @@ def _(common, df_reset, latitude, longitude, mo, monitoring, tadc):
             # trace context that is still current, and the span's own
             # __exit__ would have already torn that down by the time an
             # outer `except` ran.
-            event_id = monitoring.report(
+            _event_id = monitoring.report(
                 error,
                 where="calculate_datums.tadc_run",
                 level="error",
@@ -194,7 +194,7 @@ def _(common, df_reset, latitude, longitude, mo, monitoring, tadc):
                     kind="error",
                     title="Error",
                     content=f"Error trying to calculate datums: {error}",
-                    sentry_event_id=event_id,
+                    sentry_event_id=_event_id,
                 ),
             )
     return (out,)

--- a/climatology.py
+++ b/climatology.py
@@ -9,11 +9,12 @@ with app.setup:
 
     import climatology_core as core
     import common
+    import monitoring
 
 
 @app.cell
 def _():
-    common.set_defaults()
+    common.set_defaults(page="climatology")
     common.sidebar_menu()
 
 
@@ -215,7 +216,8 @@ def _(average_period_dropdown, end_year_dropdown, start_year_dropdown):
 @app.cell
 def _(average_period_dropdown, column, df_no_index, query_params):
     _period = average_period_dropdown.value
-    means = core.period_means(df_no_index, column, _period)
+    with monitoring.operation("climatology.period_means", op="compute"):
+        means = core.period_means(df_no_index, column, _period)
 
     _per = "day" if _period == core.DAILY else "month"
     _threshold_chart = (
@@ -271,12 +273,13 @@ def _(average_period_dropdown, column, df_no_index, query_params):
 
 @app.cell
 def _(end_year_dropdown, means, start_year_dropdown, threshold):
-    means_filtered = core.filter_means(
-        means,
-        threshold=threshold.value,
-        start_year=start_year_dropdown.value,
-        end_year=end_year_dropdown.value,
-    )
+    with monitoring.operation("climatology.filter_means", op="compute"):
+        means_filtered = core.filter_means(
+            means,
+            threshold=threshold.value,
+            start_year=start_year_dropdown.value,
+            end_year=end_year_dropdown.value,
+        )
     # means_filtered
     return (means_filtered,)
 
@@ -292,7 +295,8 @@ def _(
     _period = average_period_dropdown.value
     time_col = core.time_column(_period)
 
-    clim_df = core.climatology(means_filtered, _period, year_dropdown.value)
+    with monitoring.operation("climatology.climatology", op="compute"):
+        clim_df = core.climatology(means_filtered, _period, year_dropdown.value)
 
     _range = f"({start_year_dropdown.value} - {end_year_dropdown.value})"
     mean_range_name = f"Mean {_range}"

--- a/climatology.py
+++ b/climatology.py
@@ -129,6 +129,7 @@ def _(ts):
                     str(error),
                     title="Data Load Error",
                     kind="error",
+                    sentry_event_id=error.sentry_event_id,
                 ),
             )
     return (df_all,)

--- a/common.py
+++ b/common.py
@@ -6,6 +6,8 @@ import altair as alt
 import marimo as mo
 import pandas as pd
 
+import monitoring
+
 # Maximum number of rows that Altair will render
 MAX_ROWS = 10_000
 
@@ -32,6 +34,15 @@ ERDDAP_TIMEOUT = (10, 180)
 HTTP_TIMEOUT = 30
 
 
+def tag_page(page: str) -> None:
+    """Tag this kernel's Sentry events with the notebook page it came from.
+
+    ``root.py`` has no other setup to hang this on, so it calls this directly
+    rather than through ``set_defaults()``.
+    """
+    monitoring.tag_page(page)
+
+
 class ErddapLoadError(Exception):
     """A timeseries could not be loaded from ERDDAP.
 
@@ -41,8 +52,16 @@ class ErddapLoadError(Exception):
     """
 
 
-def set_defaults():
-    """Set common defaults for the app."""
+def set_defaults(page: str | None = None):
+    """Set common defaults for the app.
+
+    ``page`` tags every Sentry event from this notebook's kernel thread with
+    the page it came from, so a reported cell error is traceable to the
+    notebook the user was on.
+    """
+    if page:
+        tag_page(page)
+
     pd.set_option("display.precision", 2)
 
     # Inline chart data in the vega spec rather than marimo's default of
@@ -66,15 +85,23 @@ def load_platform_json(visibility: str | None = None):
     """
     import httpx2
 
-    platform_res = httpx2.get(
-        BUOY_BARN_PLATFORMS,
-        params={"visibility": visibility} if visibility else None,
-        timeout=HTTP_TIMEOUT,
-    )
-    if platform_res.status_code != 200:
-        msg = f"Failed to load platforms: {platform_res.status_code}"
-        raise ValueError(msg)
-    return platform_res.json()
+    with monitoring.operation(
+        "buoy-barn platforms",
+        op="http.client",
+        visibility=visibility,
+    ) as span:
+        platform_res = httpx2.get(
+            BUOY_BARN_PLATFORMS,
+            params={"visibility": visibility} if visibility else None,
+            timeout=HTTP_TIMEOUT,
+        )
+        if platform_res.status_code != 200:
+            msg = f"Failed to load platforms: {platform_res.status_code}"
+            raise ValueError(msg)
+        platforms = platform_res.json()
+        if span is not None:
+            span.set_data("feature_count", len(platforms.get("features", ())))
+        return platforms
 
 
 def platforms_by_name(platform_json: dict) -> dict:
@@ -164,10 +191,29 @@ def load_ts_from_erddap(ts: dict) -> pd.DataFrame:
 
     e = erddap_client(ts)
     try:
-        df = e.to_pandas(index_col="time (UTC)", parse_dates=True)
+        with monitoring.operation(
+            f"erddap {ts['dataset']}",
+            op="http.client",
+            server=ts["server"],
+            dataset=ts["dataset"],
+            variable=ts["variable"],
+        ):
+            df = e.to_pandas(index_col="time (UTC)", parse_dates=True)
     except (requests.exceptions.RequestException, OSError, ValueError) as error:
         # ERDDAP answers a rejected request with a non-CSV body, which reaches
-        # us as a pandas parse error rather than as an HTTP failure.
+        # us as a pandas parse error rather than as an HTTP failure. Reported
+        # here, before wrapping, since every caller of this function handles
+        # ErddapLoadError and it would otherwise never reach Sentry. Grouped
+        # by server rather than dataset: an ERDDAP outage should be one
+        # alertable issue with many events, not one issue per dataset.
+        monitoring.report(
+            error,
+            where="erddap.load_ts",
+            level="warning",
+            fingerprint=["erddap-load", ts["server"]],
+            dataset=ts["dataset"],
+            variable=ts["variable"],
+        )
         msg = f"Could not load {ts['dataset']} from {ts['server']}: {error}"
         raise ErddapLoadError(msg) from error
     return df.dropna()
@@ -336,15 +382,35 @@ def admonition(
     content: str,
     title: str = "Attention",
     kind: str = "admonition",
+    *,
+    report: bool | None = None,
 ):
     """Create an admonition.
 
-    kind can be admonition, attention, warning, or error"""
+    kind can be admonition, attention, warning, or error
+
+    ``report`` offers a link that opens the Sentry feedback form. It defaults
+    to on for errors when browser monitoring is configured, and is always off
+    otherwise so the link is never a dead click. The trigger is a data
+    attribute rather than an ``onclick``: marimo runs rendered HTML through
+    DOMPurify (which strips event handlers) and then html-react-parser, so the
+    click is handled by delegation in the snippet ``monitoring.html_head()``
+    injects.
+    """
+    if report is None:
+        report = kind == "error" and monitoring.enabled()
+
+    footer = (
+        '\n\n<a href="#" data-sentry-report="admonition">'
+        "Tell us what you were doing</a>"
+        if report
+        else ""
+    )
     return mo.md(
         f"""
         /// {kind} | {title}
 
-        {content}
+        {content}{footer}
         ///
         """,
     )

--- a/common.py
+++ b/common.py
@@ -400,9 +400,17 @@ def admonition(
     if report is None:
         report = kind == "error" and monitoring.enabled()
 
+    # No newline before this: mo.md() runs the whole string through
+    # inspect.cleandoc(), which dedents by the *smallest* common leading
+    # whitespace across all lines. A footer on its own line would start at
+    # column 0 while every other line here sits at this function's source
+    # indentation, so cleandoc would find a common indent of zero, leave the
+    # ///-fenced lines exactly as indented as they are in the source, and the
+    # indented /// markers would then fail to parse as a directive at all --
+    # rendering as literal text instead of a styled admonition. Keeping the
+    # link on the same line as content sidesteps that entirely.
     footer = (
-        '\n\n<a href="#" data-sentry-report="admonition">'
-        "Tell us what you were doing</a>"
+        ' <a href="#" data-sentry-report="admonition">Tell us what you were doing</a>'
         if report
         else ""
     )

--- a/common.py
+++ b/common.py
@@ -1,5 +1,6 @@
 import base64
 import functools
+import re
 from pathlib import Path
 
 import altair as alt
@@ -49,7 +50,17 @@ class ErddapLoadError(Exception):
     erddapy talks to ERDDAP with ``requests``, so pages catching httpx
     exceptions never caught anything at all. Wrapping the failure in one
     exception type keeps the pages out of that business entirely.
+
+    ``sentry_event_id`` carries the id of the Sentry event this failure was
+    already reported under (see ``load_ts_from_erddap``), so a caller
+    building an admonition from this exception can offer it back to
+    ``common.admonition(..., sentry_event_id=...)`` and let a feedback
+    submission be linked to this exact event.
     """
+
+    def __init__(self, message: str, *, sentry_event_id: str | None = None) -> None:
+        super().__init__(message)
+        self.sentry_event_id = sentry_event_id
 
 
 def set_defaults(page: str | None = None):
@@ -190,32 +201,38 @@ def load_ts_from_erddap(ts: dict) -> pd.DataFrame:
     import requests
 
     e = erddap_client(ts)
-    try:
-        with monitoring.operation(
-            f"erddap {ts['dataset']}",
-            op="http.client",
-            server=ts["server"],
-            dataset=ts["dataset"],
-            variable=ts["variable"],
-        ):
+    with monitoring.operation(
+        f"erddap {ts['dataset']}",
+        op="http.client",
+        server=ts["server"],
+        dataset=ts["dataset"],
+        variable=ts["variable"],
+    ):
+        try:
             df = e.to_pandas(index_col="time (UTC)", parse_dates=True)
-    except (requests.exceptions.RequestException, OSError, ValueError) as error:
-        # ERDDAP answers a rejected request with a non-CSV body, which reaches
-        # us as a pandas parse error rather than as an HTTP failure. Reported
-        # here, before wrapping, since every caller of this function handles
-        # ErddapLoadError and it would otherwise never reach Sentry. Grouped
-        # by server rather than dataset: an ERDDAP outage should be one
-        # alertable issue with many events, not one issue per dataset.
-        monitoring.report(
-            error,
-            where="erddap.load_ts",
-            level="warning",
-            fingerprint=["erddap-load", ts["server"]],
-            dataset=ts["dataset"],
-            variable=ts["variable"],
-        )
-        msg = f"Could not load {ts['dataset']} from {ts['server']}: {error}"
-        raise ErddapLoadError(msg) from error
+        except (requests.exceptions.RequestException, OSError, ValueError) as error:
+            # ERDDAP answers a rejected request with a non-CSV body, which
+            # reaches us as a pandas parse error rather than as an HTTP
+            # failure. Reported here, before wrapping, since every caller of
+            # this function handles ErddapLoadError and it would otherwise
+            # never reach Sentry. Grouped by server rather than dataset: an
+            # ERDDAP outage should be one alertable issue with many events,
+            # not one issue per dataset.
+            #
+            # Reported from inside the span (not after this `with` block
+            # exits): capture_exception() only picks up trace context that is
+            # still current, and the span's own __exit__ would have already
+            # torn that down by the time an outer `except` ran.
+            event_id = monitoring.report(
+                error,
+                where="erddap.load_ts",
+                level="warning",
+                fingerprint=["erddap-load", ts["server"]],
+                dataset=ts["dataset"],
+                variable=ts["variable"],
+            )
+            msg = f"Could not load {ts['dataset']} from {ts['server']}: {error}"
+            raise ErddapLoadError(msg, sentry_event_id=event_id) from error
     return df.dropna()
 
 
@@ -384,6 +401,7 @@ def admonition(
     kind: str = "admonition",
     *,
     report: bool | None = None,
+    sentry_event_id: str | None = None,
 ):
     """Create an admonition.
 
@@ -396,9 +414,22 @@ def admonition(
     DOMPurify (which strips event handlers) and then html-react-parser, so the
     click is handled by delegation in the snippet ``monitoring.html_head()``
     injects.
+
+    ``sentry_event_id`` -- the id of a Sentry event this admonition's failure
+    was already reported under, e.g. ``ErddapLoadError.sentry_event_id`` --
+    lets a feedback submission made from this admonition's link be linked to
+    that specific event, via the ``beforeSendFeedback`` hook in
+    ``monitoring.html_head()``, rather than floating free of it.
     """
     if report is None:
         report = kind == "error" and monitoring.enabled()
+
+    # Sentry's own event ids are 32 lowercase hex characters; anything else is
+    # not a real one, and this is the only guard before it goes straight into
+    # an HTML attribute.
+    event_attr = ""
+    if report and sentry_event_id and re.fullmatch(r"[0-9a-f]{32}", sentry_event_id):
+        event_attr = f' data-sentry-event-id="{sentry_event_id}"'
 
     # No newline before this: mo.md() runs the whole string through
     # inspect.cleandoc(), which dedents by the *smallest* common leading
@@ -410,7 +441,8 @@ def admonition(
     # rendering as literal text instead of a styled admonition. Keeping the
     # link on the same line as content sidesteps that entirely.
     footer = (
-        ' <a href="#" data-sentry-report="admonition">Tell us what you were doing</a>'
+        f' <a href="#" data-sentry-report="admonition"{event_attr}>'
+        "Tell us what you were doing</a>"
         if report
         else ""
     )

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,16 +21,26 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            # A DSN is not secret in the cryptographic sense -- the browser
-            # feedback widget publishes the same value in every page. The
-            # Secret keeps it out of git and away from gitleaks, nothing more.
-            # `optional: true` means the pod still starts if the Secret does
-            # not exist yet; the app treats an unset SENTRY_DSN as "off".
+            # A DSN is not secret in the cryptographic sense -- Sentry events
+            # can only be written with it, not read. The Secret keeps it out
+            # of git and away from gitleaks, nothing more. `optional: true`
+            # means the pod still starts if the Secret does not exist yet;
+            # the app treats an unset SENTRY_DSN as "off".
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
                   name: climatology-sentry
                   key: dsn
+                  optional: true
+            # Unlike the DSN, this one is genuinely public -- it is injected
+            # into every page's HTML source verbatim. Kept in the same Secret
+            # anyway so the two travel together; find it on the Sentry
+            # project's Settings -> Loader Script page.
+            - name: SENTRY_LOADER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: climatology-sentry
+                  key: loader-url
                   optional: true
             - name: SENTRY_ENVIRONMENT
               value: production

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -20,6 +20,22 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          env:
+            # A DSN is not secret in the cryptographic sense -- the browser
+            # feedback widget publishes the same value in every page. The
+            # Secret keeps it out of git and away from gitleaks, nothing more.
+            # `optional: true` means the pod still starts if the Secret does
+            # not exist yet; the app treats an unset SENTRY_DSN as "off".
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: climatology-sentry
+                  key: dsn
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              value: production
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              value: "0.2"
           livenessProbe:
             httpGet:
               port: http

--- a/monitoring.py
+++ b/monitoring.py
@@ -253,11 +253,21 @@ def report(
     level: str = "error",
     fingerprint: list[str] | None = None,
     **tags: str,
-) -> None:
+) -> str | None:
     """Report an exception that was handled and will not propagate.
 
     Wrapped in a fresh scope so tags never leak onto the next report made from
-    the same long-lived kernel thread.
+    the same long-lived kernel thread. Returns the Sentry event id (or None
+    when there is no active client) so a caller can offer it back to the
+    browser -- see common.admonition()'s ``sentry_event_id`` -- letting a
+    feedback submission made from that specific admonition be linked to this
+    exact event instead of floating free of it.
+
+    Call this from *inside* whatever ``operation()`` span was active for the
+    work that failed, not after it has already exited: capture_exception()
+    only picks up trace/span context that is still current, and a `with`
+    block's __exit__ has already torn that down by the time an enclosing
+    `except` runs.
     """
     with sentry_sdk.isolation_scope() as scope:
         scope.set_tag("where", where)
@@ -266,7 +276,7 @@ def report(
             scope.set_tag(key, value)
         if fingerprint:
             scope.fingerprint = fingerprint
-        sentry_sdk.capture_exception(error)
+        return sentry_sdk.capture_exception(error)
 
 
 def tag_page(page: str) -> None:
@@ -384,6 +394,12 @@ _HEAD = Template("""
   // bundle this replaced, no defer/async is needed for Sentry's handlers to
   // be installed before marimo's own <script type="module"> boots.
   if (window.Sentry) {
+    // Set right before a feedback form is opened from a specific admonition,
+    // and consumed (then cleared) by the beforeSendFeedback listener below --
+    // see the click handler and admonition() (common.py) for where the id
+    // comes from.
+    var pendingAssociatedEventId = null;
+
     Sentry.onLoad(function () {
       var options = $options;
       options.integrations = [
@@ -403,6 +419,21 @@ _HEAD = Template("""
         })
       ];
       Sentry.init(options);
+
+      // feedbackIntegration()'s widget has no config option for linking a
+      // submission to a specific error event -- associatedEventId only
+      // exists on the low-level Sentry.captureFeedback() call the widget
+      // doesn't expose. beforeSendFeedback is a client-level escape hatch
+      // that runs on every feedback send, widget-submitted or not, and gets
+      // the constructed event by reference before it is sent -- mutating it
+      // here is what lets a feedback submitted from the widget still end up
+      // linked to the backend error the user clicked "report" on.
+      Sentry.getClient().on("beforeSendFeedback", function (feedbackEvent) {
+        if (pendingAssociatedEventId) {
+          feedbackEvent.contexts.feedback.associated_event_id = pendingAssociatedEventId;
+          pendingAssociatedEventId = null;
+        }
+      });
     });
 
     // marimo re-renders cells continuously, and runs everything it renders
@@ -417,6 +448,7 @@ _HEAD = Template("""
       var trigger = target.closest("[data-sentry-report]");
       if (!trigger) { return; }
       event.preventDefault();
+      pendingAssociatedEventId = trigger.getAttribute("data-sentry-event-id") || null;
       Sentry.onLoad(function () {
         var feedback = Sentry.getFeedback();
         if (!feedback) { return; }

--- a/monitoring.py
+++ b/monitoring.py
@@ -1,8 +1,10 @@
 """Sentry wiring: errors, traces, logs, and the browser feedback widget.
 
-Everything here is a no-op when ``SENTRY_DSN`` is unset, which is every local
-run, the devcontainer, and CI -- none of those set the variable, so none of
-them talk to Sentry or load a third-party script.
+Backend monitoring is a no-op when ``SENTRY_DSN`` is unset; the browser widget
+additionally needs ``SENTRY_LOADER_URL`` (Sentry's hosted loader script for a
+project, from that project's Loader Script settings). Local runs, the
+devcontainer, and CI leave both unset, so none of them talk to Sentry or load
+a third-party script.
 
 marimo runs each notebook's cells on a kernel that is a *thread* of the server
 process in run mode, not a subprocess (``marimo._session.managers.kernel``),
@@ -27,6 +29,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import threading
 from dataclasses import dataclass
 from string import Template
@@ -63,22 +66,6 @@ try:
     )
 except ImportError:
     _CONTROL_FLOW_TYPES = ()
-
-# Pinned the way this repo pins its GitHub Actions: the version is in the URL
-# and the sha384 is the browser's equivalent of a digest, so the file that
-# runs on every page cannot change under us. To bump, update both constants:
-#   curl -fsSL https://browser.sentry-cdn.com/<version>/bundle.tracing.replay.feedback.min.js \
-#     | openssl dgst -sha384 -binary | openssl base64 -A
-# Sentry publishes matching hashes on its "Install (CDN)" docs page for each
-# release. Renovate is deliberately not wired up for this -- it would bump the
-# URL and leave the old hash behind, and the browser would then refuse to run
-# the script, silently disabling the widget in production.
-SENTRY_SDK_VERSION = "FILL-IN"  # e.g. "10.x.y" -- see comment above
-SENTRY_SDK_SRI = "sha384-FILL-IN"
-SENTRY_SDK_URL = (
-    f"https://browser.sentry-cdn.com/{SENTRY_SDK_VERSION}"
-    "/bundle.tracing.replay.feedback.min.js"
-)
 
 # A tenth of page loads is enough to see how the app performs without
 # spending the whole event quota on a public dashboard. Errors are always
@@ -117,6 +104,17 @@ class Settings:
     environment: str | None = None
     release: str | None = None
     traces_sample_rate: float = _DEFAULT_TRACES_SAMPLE_RATE
+    # Sentry's hosted loader script for a project (Settings -> Loader Script
+    # in the Sentry UI). It is a small, always-current shim: Sentry serves
+    # updates behind this URL from their own CDN, so unlike a versioned
+    # bundle there is no version or SRI hash to track and bump in this repo
+    # -- the trust boundary is Sentry's CDN itself, same as for any other
+    # hosted snippet. The DSN is baked into this URL server-side already;
+    # Sentry.onLoad() in html_head() is what lets this file pin the
+    # integrations and their options explicitly instead of trusting whatever
+    # is toggled on the dashboard's Loader Script settings page. Example:
+    # SENTRY_LOADER_URL=https://js.sentry-cdn.com/<key>.min.js
+    loader_url: str = ""
 
     @classmethod
     def from_env(cls) -> Settings:
@@ -128,6 +126,7 @@ class Settings:
                 "SENTRY_TRACES_SAMPLE_RATE",
                 _DEFAULT_TRACES_SAMPLE_RATE,
             ),
+            loader_url=_loader_url_env("SENTRY_LOADER_URL"),
         )
 
 
@@ -140,6 +139,20 @@ def _float_env(name: str, default: float) -> float:
     except ValueError:
         LOGGER.warning("Ignoring %s: %r is not a number", name, value)
         return default
+
+
+# Sentry's own dashboard hands this out as a whole <script src="...
+# crossorigin="anonymous"></script> tag under the literal heading "Loader
+# Script" -- pasting that entire tag as the env var's value, rather than
+# picking the URL back out of it, is the natural mistake. Tolerate it rather
+# than merely warn about it.
+_SCRIPT_SRC_RE = re.compile(r"""src\s*=\s*["']([^"']+)["']""")
+
+
+def _loader_url_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    match = _SCRIPT_SRC_RE.search(value)
+    return match.group(1) if match else value
 
 
 def _traces_sampler(sampling_context: dict) -> float:
@@ -223,8 +236,14 @@ def init_sentry() -> bool:
 
 
 def enabled() -> bool:
-    """Whether monitoring is configured -- the browser widget asks this too."""
-    return bool(Settings.from_env().dsn)
+    """Whether the browser widget is configured and will actually render.
+
+    Used by common.admonition() to decide whether its "tell us what you were
+    doing" link has anything to open -- which needs both variables, the same
+    as html_head() below.
+    """
+    settings = Settings.from_env()
+    return bool(settings.dsn) and bool(settings.loader_url)
 
 
 def report(
@@ -356,32 +375,35 @@ def _capture_cell_exception(cell: Any, _ctx: Any, run_result: Any) -> None:
 
 
 _HEAD = Template("""
-<link rel="preconnect" href="https://browser.sentry-cdn.com" crossorigin>
-<script src="$url" integrity="$sri" crossorigin="anonymous"></script>
+<link rel="preconnect" href="https://js.sentry-cdn.com" crossorigin>
+<script src="$loader_url" crossorigin="anonymous"></script>
 <script>
-  // marimo's own bundle is a <script type="module">, which is deferred, so
-  // this classic script runs first even though marimo injects it later in
-  // the head. That ordering is what lets Sentry install its handlers before
-  // marimo boots -- do not add defer/async to the script tag above.
+  // The loader is a small, synchronous shim: it registers window.Sentry and
+  // queues onLoad callbacks immediately, then fetches the full SDK in the
+  // background and runs this callback once it lands -- so, like the versioned
+  // bundle this replaced, no defer/async is needed for Sentry's handlers to
+  // be installed before marimo's own <script type="module"> boots.
   if (window.Sentry) {
-    var options = $options;
-    options.integrations = [
-      Sentry.browserTracingIntegration(),
-      // Replays are only kept when something went wrong -- that is the
-      // "what were they doing beforehand" the issue asks for, without
-      // recording every visitor to a public dashboard.
-      Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
-      Sentry.feedbackIntegration({
-        colorScheme: "system",
-        showBranding: false,
-        triggerLabel: "Report a problem",
-        formTitle: "Report a problem",
-        messagePlaceholder: "What were you trying to do?",
-        isNameRequired: false,
-        isEmailRequired: false
-      })
-    ];
-    Sentry.init(options);
+    Sentry.onLoad(function () {
+      var options = $options;
+      options.integrations = [
+        Sentry.browserTracingIntegration(),
+        // Replays are only kept when something went wrong -- that is the
+        // "what were they doing beforehand" the issue asks for, without
+        // recording every visitor to a public dashboard.
+        Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
+        Sentry.feedbackIntegration({
+          colorScheme: "system",
+          showBranding: false,
+          triggerLabel: "Report a problem",
+          formTitle: "Report a problem",
+          messagePlaceholder: "What were you trying to do?",
+          isNameRequired: false,
+          isEmailRequired: false
+        })
+      ];
+      Sentry.init(options);
+    });
 
     // marimo re-renders cells continuously, and runs everything it renders
     // through DOMPurify and then html-react-parser, which between them drop
@@ -395,14 +417,16 @@ _HEAD = Template("""
       var trigger = target.closest("[data-sentry-report]");
       if (!trigger) { return; }
       event.preventDefault();
-      var feedback = Sentry.getFeedback();
-      if (!feedback) { return; }
-      Promise.resolve(feedback.createForm({
-        formTitle: "Report a problem",
-        messagePlaceholder: "What were you doing when this happened?"
-      })).then(function (form) {
-        form.appendToDom();
-        form.open();
+      Sentry.onLoad(function () {
+        var feedback = Sentry.getFeedback();
+        if (!feedback) { return; }
+        Promise.resolve(feedback.createForm({
+          formTitle: "Report a problem",
+          messagePlaceholder: "What were you doing when this happened?"
+        })).then(function (form) {
+          form.appendToDom();
+          form.open();
+        });
       });
     });
   }
@@ -413,21 +437,28 @@ _HEAD = Template("""
 def html_head() -> str | None:
     """The <head> snippet for ``marimo.create_asgi_app(html_head=...)``.
 
-    None when there is no configured DSN, which is what keeps local runs, the
-    devcontainer, and the CI end-to-end suite free of any third-party script.
+    None unless both SENTRY_DSN and SENTRY_LOADER_URL are set, which is what
+    keeps local runs, the devcontainer, and the CI end-to-end suite free of
+    any third-party script.
     """
     settings = Settings.from_env()
-    if not settings.dsn:
+    if not settings.dsn or not settings.loader_url:
         return None
-    if not settings.dsn.startswith("https://"):
-        # A mis-set variable would otherwise be interpolated straight into a
-        # <script> block -- refuse anything that is not shaped like a DSN
-        # rather than risk that.
-        LOGGER.warning("Ignoring SENTRY_DSN: expected an https:// DSN")
+    if not settings.loader_url.startswith("https://"):
+        # Unlike the other settings below, this one is written straight into
+        # an HTML attribute rather than through json.dumps -- refuse anything
+        # that is not shaped like a URL rather than risk a malformed
+        # SENTRY_LOADER_URL breaking out of the src="..." attribute.
+        LOGGER.warning("Ignoring SENTRY_LOADER_URL: expected an https:// URL")
         return None
 
+    # No "dsn" key: the loader URL already has one baked in server-side (see
+    # Settings.loader_url). SENTRY_DSN only toggles whether this snippet is
+    # injected at all -- it does not have to name the same Sentry project as
+    # the loader, which matters when pointing SENTRY_DSN at a personal
+    # project for local testing (see README.md): backend events follow it,
+    # browser events still go to the project the loader is configured for.
     options: dict[str, Any] = {
-        "dsn": settings.dsn,
         "tracesSampleRate": settings.traces_sample_rate,
         "replaysSessionSampleRate": 0,
         "replaysOnErrorSampleRate": 1.0,
@@ -445,8 +476,7 @@ def html_head() -> str | None:
         options["release"] = settings.release
 
     return _HEAD.substitute(
-        url=SENTRY_SDK_URL,
-        sri=SENTRY_SDK_SRI,
+        loader_url=settings.loader_url,
         # json.dumps handles quotes, backslashes and control characters. It
         # leaves "<" alone, so a value containing "</script>" would close the
         # block early -- escaping "<" keeps the literal inert without

--- a/monitoring.py
+++ b/monitoring.py
@@ -1,0 +1,455 @@
+"""Sentry wiring: errors, traces, logs, and the browser feedback widget.
+
+Everything here is a no-op when ``SENTRY_DSN`` is unset, which is every local
+run, the devcontainer, and CI -- none of those set the variable, so none of
+them talk to Sentry or load a third-party script.
+
+marimo runs each notebook's cells on a kernel that is a *thread* of the server
+process in run mode, not a subprocess (``marimo._session.managers.kernel``),
+so a single ``init_sentry()`` call in ``app.py`` covers the ASGI server and
+every notebook. But marimo never routes a cell's exception through
+``logging`` -- ``cell_runner._finalize_run_result`` parks it on
+``RunResult.exception`` and writes the traceback straight to the browser --
+so no Sentry integration sees a cell failure on its own. ``install_marimo_hook``
+below is what makes that visible; see its docstring for how and why.
+
+Kernel-side tracing (``operation``) is deliberately out of scope for anything
+beyond a handful of call sites: marimo's own reactive-run and preparation/
+on-finish hooks would let a transaction span an entire user interaction, but
+that is more private API for uncertain benefit and is left for a follow-up.
+marimo's own OpenTelemetry support (``marimo._tracer``) is opt-in and would
+double-instrument if enabled alongside this module.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from string import Template
+from typing import TYPE_CHECKING, Any
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.threading import ThreadingIntegration
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+LOGGER = logging.getLogger(__name__)
+
+# Paths that carry no signal and would otherwise dominate the trace budget:
+# the k8s liveness/readiness/startup probes and the Docker HEALTHCHECK hit
+# /health roughly every 10s, granian serves /static itself, and marimo serves
+# /assets and /@file.
+_UNTRACED_PATHS = frozenset({"/health", "/favicon.ico", "/public-files-sw.js"})
+_UNTRACED_PREFIXES = ("/assets/", "/@file/", "/static/")
+
+# marimo's control-flow signals, not failures:
+# - MarimoStopError is how every page says "nothing selected yet" (mo.stop).
+# - MarimoInterrupt is an alias for KeyboardInterrupt (marimo._runtime.control_flow).
+# Both are BaseException-only, so `isinstance(exc, Exception)` already excludes
+# them -- kept as a second, explicit check in case a future marimo reparents
+# one of them under Exception.
+try:
+    from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
+
+    _CONTROL_FLOW_TYPES: tuple[type[BaseException], ...] = (
+        MarimoStopError,
+        MarimoInterrupt,
+    )
+except ImportError:
+    _CONTROL_FLOW_TYPES = ()
+
+# Pinned the way this repo pins its GitHub Actions: the version is in the URL
+# and the sha384 is the browser's equivalent of a digest, so the file that
+# runs on every page cannot change under us. To bump, update both constants:
+#   curl -fsSL https://browser.sentry-cdn.com/<version>/bundle.tracing.replay.feedback.min.js \
+#     | openssl dgst -sha384 -binary | openssl base64 -A
+# Sentry publishes matching hashes on its "Install (CDN)" docs page for each
+# release. Renovate is deliberately not wired up for this -- it would bump the
+# URL and leave the old hash behind, and the browser would then refuse to run
+# the script, silently disabling the widget in production.
+SENTRY_SDK_VERSION = "FILL-IN"  # e.g. "10.x.y" -- see comment above
+SENTRY_SDK_SRI = "sha384-FILL-IN"
+SENTRY_SDK_URL = (
+    f"https://browser.sentry-cdn.com/{SENTRY_SDK_VERSION}"
+    "/bundle.tracing.replay.feedback.min.js"
+)
+
+# A tenth of page loads is enough to see how the app performs without
+# spending the whole event quota on a public dashboard. Errors are always
+# captured regardless of this setting -- it only governs performance traces.
+_DEFAULT_TRACES_SAMPLE_RATE = 0.0
+
+
+@dataclass
+class _State:
+    """Mutable process-wide state, kept in one object rather than as
+    module-level names rebound with ``global`` (which ruff's PLW0603 flags).
+    """
+
+    initialised_pid: int | None = None
+    hook_installed: bool = False
+
+
+_state = _State()
+
+# One kernel thread per notebook session in run mode, so a plain thread-local
+# is enough to remember which page it is running -- Sentry's own Scope has no
+# public API to read a tag back, only to write one.
+_page = threading.local()
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Sentry configuration, read from the environment once per call.
+
+    Kept as a plain object (rather than reading os.environ inline everywhere)
+    so tests can construct one directly instead of monkeypatching the process
+    environment for every case.
+    """
+
+    dsn: str = ""
+    environment: str | None = None
+    release: str | None = None
+    traces_sample_rate: float = _DEFAULT_TRACES_SAMPLE_RATE
+
+    @classmethod
+    def from_env(cls) -> Settings:
+        return cls(
+            dsn=os.environ.get("SENTRY_DSN", "").strip(),
+            environment=os.environ.get("SENTRY_ENVIRONMENT", "").strip() or None,
+            release=os.environ.get("SENTRY_RELEASE", "").strip() or None,
+            traces_sample_rate=_float_env(
+                "SENTRY_TRACES_SAMPLE_RATE",
+                _DEFAULT_TRACES_SAMPLE_RATE,
+            ),
+        )
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if not value:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        LOGGER.warning("Ignoring %s: %r is not a number", name, value)
+        return default
+
+
+def _traces_sampler(sampling_context: dict) -> float:
+    asgi_scope = sampling_context.get("asgi_scope") or {}
+    if asgi_scope:
+        # One websocket per open browser tab, held for the tab's whole
+        # lifetime -- sampling those produces hours-long transactions with no
+        # spans in them.
+        if asgi_scope.get("type") != "http":
+            return 0.0
+        path = asgi_scope.get("path", "")
+        if path in _UNTRACED_PATHS or path.startswith(_UNTRACED_PREFIXES):
+            return 0.0
+    return Settings.from_env().traces_sample_rate
+
+
+def _before_send_log(log: dict, _hint: dict) -> dict | None:
+    # The `serve` pixi task runs granian with --access-log; at INFO that is one
+    # access-log line per request, health probes included, and enable_logs
+    # would otherwise ship every one of them to Sentry.
+    name = (log.get("attributes") or {}).get("logger.name", "")
+    if name.startswith(("granian.access", "uvicorn.access")):
+        return None
+    return log
+
+
+def sentry_options(settings: Settings | None = None) -> dict:
+    """The kwargs ``init_sentry`` passes to ``sentry_sdk.init``.
+
+    Split out so tests can re-init with a fake DSN and a capturing transport
+    without a network connection or a real Sentry project.
+    """
+    settings = settings or Settings.from_env()
+    return {
+        "dsn": settings.dsn,
+        "environment": settings.environment,
+        "release": settings.release,
+        # Public, unauthenticated dashboard -- no client IPs, cookies, or
+        # request bodies. The query string (platform, data type, date range)
+        # still comes through on each event and is the real reproduction
+        # payload.
+        "send_default_pii": False,
+        "max_request_body_size": "never",
+        "traces_sampler": _traces_sampler,
+        "enable_logs": True,
+        "before_send_log": _before_send_log,
+        "integrations": [
+            # Kernel threads live for the whole browser session; with the
+            # default (True) every event from a kernel would be permanently
+            # stamped with the HTTP request that opened its websocket.
+            ThreadingIntegration(propagate_scope=False),
+            # Breadcrumbs and Sentry Logs, but no issues manufactured from log
+            # records -- marimo's own LOGGER.exception calls still surface as
+            # logs rather than duplicate issues.
+            LoggingIntegration(
+                level=logging.INFO,
+                event_level=None,
+                sentry_logs_level=logging.WARNING,
+            ),
+        ],
+    }
+
+
+def init_sentry() -> bool:
+    """Start the Sentry SDK. Idempotent per process. False when there is no DSN.
+
+    Skipping init entirely when the DSN is empty (rather than calling
+    ``sentry_sdk.init(dsn="")``) means "off" is really off: no client, no
+    patched Starlette middleware, no patched threading module.
+    """
+    settings = Settings.from_env()
+    if not settings.dsn:
+        return False
+    if _state.initialised_pid == os.getpid():
+        return True
+
+    sentry_sdk.init(**sentry_options(settings))
+    _state.initialised_pid = os.getpid()
+    install_marimo_hook()
+    return True
+
+
+def enabled() -> bool:
+    """Whether monitoring is configured -- the browser widget asks this too."""
+    return bool(Settings.from_env().dsn)
+
+
+def report(
+    error: BaseException,
+    *,
+    where: str,
+    level: str = "error",
+    fingerprint: list[str] | None = None,
+    **tags: str,
+) -> None:
+    """Report an exception that was handled and will not propagate.
+
+    Wrapped in a fresh scope so tags never leak onto the next report made from
+    the same long-lived kernel thread.
+    """
+    with sentry_sdk.isolation_scope() as scope:
+        scope.set_tag("where", where)
+        scope.set_level(level)
+        for key, value in tags.items():
+            scope.set_tag(key, value)
+        if fingerprint:
+            scope.fingerprint = fingerprint
+        sentry_sdk.capture_exception(error)
+
+
+def tag_page(page: str) -> None:
+    """Tag every event from this kernel thread with the notebook page it came
+    from. Call once per notebook (``common.set_defaults(page=...)`` does this).
+    """
+    _page.name = page
+    sentry_sdk.get_isolation_scope().set_tag("marimo.page", page)
+
+
+def _page_name() -> str:
+    tagged = getattr(_page, "name", None)
+    if tagged:
+        return tagged
+    try:
+        from marimo._runtime.context.types import safe_get_context
+
+        ctx = safe_get_context()
+        if ctx is not None and ctx.filename:
+            return ctx.filename
+    except ImportError:
+        pass
+    return "unknown"
+
+
+@contextlib.contextmanager
+def operation(name: str, op: str = "task", **data: Any) -> Iterator[Any]:
+    """A child span if a transaction is active, otherwise a new transaction.
+
+    Kernel work runs on a thread with no HTTP request behind it -- there is
+    usually nothing to be a child of -- so this opens whichever is needed. A
+    fresh scope keeps a span from a previous cell run on the same reused
+    kernel thread from becoming this one's parent.
+    """
+    if not sentry_sdk.get_client().is_active():
+        yield None
+        return
+
+    active = sentry_sdk.get_current_span()
+    with sentry_sdk.new_scope():
+        starter = (
+            sentry_sdk.start_span
+            if active is not None
+            else sentry_sdk.start_transaction
+        )
+        with starter(op=op, name=name) as span:
+            for key, value in data.items():
+                span.set_data(key, value)
+            yield span
+
+
+def install_marimo_hook() -> bool:
+    """Report exceptions raised by notebook cells.
+
+    marimo has no public hook-registration API, and it does not log cell
+    exceptions -- ``cell_runner._finalize_run_result`` parks them on
+    ``RunResult.exception`` and writes the formatted traceback straight to the
+    frontend. Appending to the private list that
+    ``marimo._runtime.runner.hooks.create_default_hooks`` copies into every
+    kernel's hooks is the only way to see them. Kernels are built per session,
+    after this module is imported at app startup, so they all pick this up.
+
+    Returns False (rather than raising) if marimo's internals have moved --
+    production then degrades to "no cell errors reported, plus one Sentry
+    message saying so" instead of failing to boot. ``tests/unit/test_monitoring.py``
+    is the real guard: it walks this same private chain, so a marimo upgrade
+    that breaks it fails CI instead of silently disabling reporting.
+    """
+    if _state.hook_installed:
+        return True
+    try:
+        from marimo._runtime.runner import hooks_post_execution as marimo_hooks
+
+        hooks = marimo_hooks.POST_EXECUTION_HOOKS
+        if not isinstance(hooks, list):
+            msg = f"expected a list, got {type(hooks)}"
+            raise TypeError(msg)
+        if _capture_cell_exception not in hooks:
+            hooks.append(_capture_cell_exception)
+    except Exception:
+        sentry_sdk.capture_message(
+            "marimo's POST_EXECUTION_HOOKS is not where monitoring.py expects "
+            "it; notebook cell errors are NOT being reported",
+            level="error",
+        )
+        return False
+    _state.hook_installed = True
+    return True
+
+
+def _capture_cell_exception(cell: Any, _ctx: Any, run_result: Any) -> None:
+    try:
+        exc = run_result.exception
+        # marimo's Error dataclasses (cascade/cycle notices) are not
+        # exceptions at all; mo.stop and interrupts are BaseException-only.
+        # Either way, isinstance(exc, Exception) already excludes them --
+        # _CONTROL_FLOW_TYPES is kept as a belt-and-braces second check.
+        if not isinstance(exc, Exception) or isinstance(exc, _CONTROL_FLOW_TYPES):
+            return
+        with sentry_sdk.isolation_scope() as scope:
+            scope.set_tag("marimo.page", _page_name())
+            scope.set_tag("marimo.cell_id", str(getattr(cell, "cell_id", "?")))
+            sentry_sdk.capture_exception(exc)
+    except Exception:
+        return  # monitoring must never break a notebook
+
+
+_HEAD = Template("""
+<link rel="preconnect" href="https://browser.sentry-cdn.com" crossorigin>
+<script src="$url" integrity="$sri" crossorigin="anonymous"></script>
+<script>
+  // marimo's own bundle is a <script type="module">, which is deferred, so
+  // this classic script runs first even though marimo injects it later in
+  // the head. That ordering is what lets Sentry install its handlers before
+  // marimo boots -- do not add defer/async to the script tag above.
+  if (window.Sentry) {
+    var options = $options;
+    options.integrations = [
+      Sentry.browserTracingIntegration(),
+      // Replays are only kept when something went wrong -- that is the
+      // "what were they doing beforehand" the issue asks for, without
+      // recording every visitor to a public dashboard.
+      Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
+      Sentry.feedbackIntegration({
+        colorScheme: "system",
+        showBranding: false,
+        triggerLabel: "Report a problem",
+        formTitle: "Report a problem",
+        messagePlaceholder: "What were you trying to do?",
+        isNameRequired: false,
+        isEmailRequired: false
+      })
+    ];
+    Sentry.init(options);
+
+    // marimo re-renders cells continuously, and runs everything it renders
+    // through DOMPurify and then html-react-parser, which between them drop
+    // inline onclick handlers -- a data attribute survives. Delegation from
+    // here needs no element to exist at bind time, unlike Sentry's own
+    // attachTo(), so it also covers the error admonitions common.py renders
+    // (see common.admonition()).
+    document.addEventListener("click", function (event) {
+      var target = event.target;
+      if (!target || !target.closest) { return; }
+      var trigger = target.closest("[data-sentry-report]");
+      if (!trigger) { return; }
+      event.preventDefault();
+      var feedback = Sentry.getFeedback();
+      if (!feedback) { return; }
+      Promise.resolve(feedback.createForm({
+        formTitle: "Report a problem",
+        messagePlaceholder: "What were you doing when this happened?"
+      })).then(function (form) {
+        form.appendToDom();
+        form.open();
+      });
+    });
+  }
+</script>
+""")
+
+
+def html_head() -> str | None:
+    """The <head> snippet for ``marimo.create_asgi_app(html_head=...)``.
+
+    None when there is no configured DSN, which is what keeps local runs, the
+    devcontainer, and the CI end-to-end suite free of any third-party script.
+    """
+    settings = Settings.from_env()
+    if not settings.dsn:
+        return None
+    if not settings.dsn.startswith("https://"):
+        # A mis-set variable would otherwise be interpolated straight into a
+        # <script> block -- refuse anything that is not shaped like a DSN
+        # rather than risk that.
+        LOGGER.warning("Ignoring SENTRY_DSN: expected an https:// DSN")
+        return None
+
+    options: dict[str, Any] = {
+        "dsn": settings.dsn,
+        "tracesSampleRate": settings.traces_sample_rate,
+        "replaysSessionSampleRate": 0,
+        "replaysOnErrorSampleRate": 1.0,
+        "sendDefaultPii": False,
+        "ignoreErrors": [
+            # Layout-thrash noise from chart resize observers, not a fault.
+            # Chromium and Firefox word it differently.
+            "ResizeObserver loop limit exceeded",
+            "ResizeObserver loop completed with undelivered notifications",
+        ],
+    }
+    if settings.environment:
+        options["environment"] = settings.environment
+    if settings.release:
+        options["release"] = settings.release
+
+    return _HEAD.substitute(
+        url=SENTRY_SDK_URL,
+        sri=SENTRY_SDK_SRI,
+        # json.dumps handles quotes, backslashes and control characters. It
+        # leaves "<" alone, so a value containing "</script>" would close the
+        # block early -- escaping "<" keeps the literal inert without
+        # changing what it evaluates to.
+        options=json.dumps(options).replace("<", "\\u003c"),
+    )

--- a/pixi.lock
+++ b/pixi.lock
@@ -245,6 +245,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
@@ -334,6 +335,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
@@ -745,6 +747,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.20.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -843,6 +846,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.20.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -3741,7 +3745,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  - pkg:pypi/scipy?source=hash-mapping
   run_exports: {}
   size: 17260022
   timestamp: 1781912924009
@@ -4317,7 +4321,7 @@ packages:
   - python >=3.10
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=compressed-mapping
+  - pkg:pypi/certifi?source=hash-mapping
   run_exports: {}
   size: 133877
   timestamp: 1781719949728
@@ -4629,7 +4633,7 @@ packages:
   - uvicorn-standard >=0.12.0
   license: MIT
   purls:
-  - pkg:pypi/fastapi?source=compressed-mapping
+  - pkg:pypi/fastapi?source=hash-mapping
   run_exports: {}
   size: 104985
   timestamp: 1785159301977
@@ -4772,7 +4776,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/hpack?source=compressed-mapping
+  - pkg:pypi/hpack?source=hash-mapping
   run_exports: {}
   size: 32884
   timestamp: 1782283986153
@@ -4876,7 +4880,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/idna?source=compressed-mapping
+  - pkg:pypi/idna?source=hash-mapping
   run_exports: {}
   size: 163869
   timestamp: 1781620148226
@@ -4902,7 +4906,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/importlib-metadata?source=compressed-mapping
+  - pkg:pypi/importlib-metadata?source=hash-mapping
   run_exports: {}
   size: 34766
   timestamp: 1779714582554
@@ -5280,7 +5284,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pydantic-settings?source=compressed-mapping
+  - pkg:pypi/pydantic-settings?source=hash-mapping
   run_exports: {}
   size: 52920
   timestamp: 1781884990751
@@ -5390,7 +5394,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest?source=compressed-mapping
+  - pkg:pypi/pytest?source=hash-mapping
   run_exports: {}
   size: 306724
   timestamp: 1782127176429
@@ -5521,7 +5525,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/python-multipart?source=compressed-mapping
+  - pkg:pypi/python-multipart?source=hash-mapping
   run_exports: {}
   size: 38132
   timestamp: 1780610429919
@@ -5683,6 +5687,20 @@ packages:
   run_exports: {}
   size: 34331
   timestamp: 1780659356824
+- conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.1-pyhd8ed1ab_0.conda
+  sha256: 2971291742000dbcfef14831be779d7fd00be23729615ba7865507ed96ac9ae6
+  md5: ffb67c032e6f46bcbffa97727927d98d
+  depends:
+  - certifi
+  - python >=3.10
+  - urllib3 >=1.25.7
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/sentry-sdk?source=hash-mapping
+  run_exports: {}
+  size: 318313
+  timestamp: 1784754730062
 - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
   sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
   md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
@@ -6012,7 +6030,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/uvicorn?source=compressed-mapping
+  - pkg:pypi/uvicorn?source=hash-mapping
   run_exports: {}
   size: 56228
   timestamp: 1780574319325
@@ -6107,7 +6125,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp?source=compressed-mapping
+  - pkg:pypi/zipp?source=hash-mapping
   run_exports: {}
   size: 24190
   timestamp: 1779159948016
@@ -8538,7 +8556,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  - pkg:pypi/scipy?source=hash-mapping
   run_exports: {}
   size: 14122215
   timestamp: 1781912992503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ scipy = ">=1.15.2,<2"
 requests = ">=2.32.5,<3"
 pydantic = ">=2.12"
 httpx2 = ">=2.5.0,<3"
+sentry-sdk = ">=2.66,<3"
 
 [tool.pixi.environments]
 test = { features = [ "test" ], solve-group = "default" }

--- a/root.py
+++ b/root.py
@@ -19,6 +19,7 @@ def _():
 
 @app.cell
 def _(common):
+    common.tag_page("root")
     common.sidebar_menu()
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -38,6 +38,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # -- nothing an end-to-end run does with it can leave the machine.
 SENTRY_E2E_DSN = "https://e2e00000000000000000000000000000@o0.ingest.invalid/1"
 
+# monitoring.py reads the loader URL itself from SENTRY_LOADER_URL, so there
+# is no hardcoded default to fall back on here. Set the real env var (e.g. in
+# a local shell) to exercise test_feedback_widget_button_appears against an
+# actual Sentry project; without it, the .invalid placeholder below is enough
+# for test_sentry_script_is_injected, which only checks the page's HTML and
+# never loads the URL.
+SENTRY_E2E_LOADER_URL = os.environ.get(
+    "SENTRY_LOADER_URL",
+    "https://js.sentry-cdn.com/e2e00000000000000000000000000000.min.js",
+)
+
 
 def _free_port() -> int:
     """Ask the OS for an unused TCP port and return it."""
@@ -129,6 +140,7 @@ def sentry_app_server() -> Generator[str | None]:
     process, base_url = _spawn_server(
         {
             "SENTRY_DSN": SENTRY_E2E_DSN,
+            "SENTRY_LOADER_URL": SENTRY_E2E_LOADER_URL,
             "SENTRY_ENVIRONMENT": "e2e",
             "SENTRY_RELEASE": "e2e",
         },

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,6 +10,11 @@ The subprocess runs the ``serve`` task from pyproject.toml, overriding only its
 host and port arguments, so a local run serves ``public/`` through granian
 exactly like the container does. Restating granian's static options here instead
 would let the two drift, and the sidebar logo would 404 in only one of them.
+
+``sentry_app_server`` (see tests/e2e/test_sentry.py) starts a second instance
+the same way, but with a dummy ``SENTRY_DSN`` set, so the Sentry-specific tests
+do not have to run against a DSN-less server the way the rest of the suite
+does.
 """
 
 import os
@@ -19,6 +24,7 @@ import subprocess
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -26,6 +32,11 @@ import pytest
 # Repository root (two levels up from tests/e2e/conftest.py) so that the app's
 # relative paths (./root.py, ./public/neracoos.png, ...) resolve.
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# RFC 2606 reserves .invalid, so this DSN is structurally valid enough for the
+# SDK to accept and configure the browser widget with, and can never resolve
+# -- nothing an end-to-end run does with it can leave the machine.
+SENTRY_E2E_DSN = "https://e2e00000000000000000000000000000@o0.ingest.invalid/1"
 
 
 def _free_port() -> int:
@@ -57,8 +68,28 @@ def _wait_until_ready(url: str, timeout: float = 60.0) -> None:
     )
 
 
+def _spawn_server(env: dict[str, str] | None = None) -> tuple[subprocess.Popen, str]:
+    """Start a fresh ``pixi run serve`` on a free port and wait for it to answer.
+
+    Extra ``env`` is layered on top of the current environment, so a caller can
+    add e.g. ``SENTRY_DSN`` without losing ``PATH`` and friends.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    process = subprocess.Popen(
+        ["pixi", "run", "serve", "127.0.0.1", str(port)],
+        cwd=str(REPO_ROOT),
+        # New session/process group so the whole tree can be signalled together.
+        start_new_session=True,
+        env={**os.environ, **(env or {})},
+    )
+    _wait_until_ready(base_url + "/", timeout=60.0)
+    return process, base_url
+
+
 @pytest.fixture(scope="session")
-def app_server() -> str:
+def app_server() -> Generator[str]:
     """Yield the base URL of the running app.
 
     Uses ``E2E_BASE_URL`` if set (no server spawned); otherwise starts granian
@@ -69,18 +100,40 @@ def app_server() -> str:
         yield external_url.rstrip("/")
         return
 
-    port = _free_port()
-    base_url = f"http://127.0.0.1:{port}"
-
-    process = subprocess.Popen(
-        ["pixi", "run", "serve", "127.0.0.1", str(port)],
-        cwd=str(REPO_ROOT),
-        # New session/process group so the whole tree can be signalled together.
-        start_new_session=True,
-    )
-
+    process, base_url = _spawn_server()
     try:
-        _wait_until_ready(base_url + "/", timeout=60.0)
+        yield base_url
+    finally:
+        _terminate(process)
+
+
+@pytest.fixture(scope="session")
+def sentry_app_server() -> Generator[str | None]:
+    """Base URL of a second app instance started with a dummy ``SENTRY_DSN``.
+
+    Honours ``E2E_SENTRY_BASE_URL`` the way ``app_server`` honours
+    ``E2E_BASE_URL``. Yields ``None`` (tests using this fixture should skip)
+    when the main suite is pointed at an external server via ``E2E_BASE_URL``
+    and no ``E2E_SENTRY_BASE_URL`` was given either -- there is then no way to
+    start a second, differently configured instance.
+    """
+    external_url = os.environ.get("E2E_SENTRY_BASE_URL")
+    if external_url:
+        yield external_url.rstrip("/")
+        return
+
+    if os.environ.get("E2E_BASE_URL"):
+        yield None
+        return
+
+    process, base_url = _spawn_server(
+        {
+            "SENTRY_DSN": SENTRY_E2E_DSN,
+            "SENTRY_ENVIRONMENT": "e2e",
+            "SENTRY_RELEASE": "e2e",
+        },
+    )
+    try:
         yield base_url
     finally:
         _terminate(process)

--- a/tests/e2e/test_pages.py
+++ b/tests/e2e/test_pages.py
@@ -123,3 +123,19 @@ def test_static_route_does_not_shadow_marimo(
     """
     response = api_request_context.get("/public-files-sw.js?v=2")
     assert response.status == 200
+
+
+@pytest.mark.parametrize("route", [route for route, _ in PAGES])
+def test_no_sentry_script_without_a_dsn(
+    api_request_context: APIRequestContext,
+    route: str,
+) -> None:
+    """With no SENTRY_DSN, the pages load no third-party script.
+
+    Local runs, the devcontainer, and this suite by default all leave the
+    variable unset, and none of them should be reaching out to a CDN or to
+    Sentry -- see monitoring.html_head().
+    """
+    body = api_request_context.get(route).text()
+    assert "sentry-cdn.com" not in body
+    assert "Sentry.init" not in body

--- a/tests/e2e/test_sentry.py
+++ b/tests/e2e/test_sentry.py
@@ -1,0 +1,69 @@
+"""End-to-end checks that the Sentry browser SDK is wired up correctly.
+
+These run against a second app instance started with a dummy ``SENTRY_DSN``
+(``sentry_app_server`` in conftest.py), so they do not interfere with the main
+suite's DSN-less assertions in test_pages.py -- and so a broken Sentry
+injection cannot make the primary pages fail to render.
+"""
+
+import os
+from collections.abc import Generator
+
+import pytest
+from playwright.sync_api import APIRequestContext, Playwright, expect
+
+
+@pytest.fixture
+def sentry_api_request_context(
+    playwright: Playwright,
+    sentry_app_server: str | None,
+) -> Generator[APIRequestContext]:
+    if sentry_app_server is None:
+        pytest.skip(
+            "no sentry_app_server available -- E2E_BASE_URL is set with no "
+            "matching E2E_SENTRY_BASE_URL",
+        )
+    context = playwright.request.new_context(base_url=sentry_app_server)
+    yield context
+    context.dispose()
+
+
+def test_sentry_script_is_injected(
+    sentry_api_request_context: APIRequestContext,
+) -> None:
+    """With SENTRY_DSN set, the pinned bundle and its SRI hash are on the page."""
+    body = sentry_api_request_context.get("/").text()
+    assert "browser.sentry-cdn.com" in body
+    assert 'integrity="sha384-' in body
+    assert "SENTRY_E2E_DSN" not in body  # sanity: the literal value, not the name
+
+
+@pytest.mark.skipif(
+    os.environ.get("E2E_SENTRY_WIDGET") != "1",
+    reason=(
+        "loads the real Sentry SDK from its CDN -- opt in with "
+        "E2E_SENTRY_WIDGET=1. Also requires monitoring.SENTRY_SDK_VERSION/"
+        "SENTRY_SDK_SRI to be filled in with real values first."
+    ),
+)
+def test_feedback_widget_button_appears(
+    playwright: Playwright,
+    sentry_app_server: str | None,
+) -> None:
+    if sentry_app_server is None:
+        pytest.skip("no sentry_app_server available")
+
+    browser = playwright.chromium.launch()
+    context = browser.new_context(base_url=sentry_app_server)
+    page = context.new_page()
+    try:
+        page.goto("/")
+        # Sentry's feedback widget renders into an open shadow root; the role
+        # locator pierces it. Fall back to page.locator("#sentry-feedback")
+        # if this ever misses on a real SDK version.
+        expect(page.get_by_role("button", name="Report a problem")).to_be_visible(
+            timeout=30_000,
+        )
+    finally:
+        context.close()
+        browser.close()

--- a/tests/e2e/test_sentry.py
+++ b/tests/e2e/test_sentry.py
@@ -10,6 +10,7 @@ import os
 from collections.abc import Generator
 
 import pytest
+from conftest import SENTRY_E2E_LOADER_URL
 from playwright.sync_api import APIRequestContext, Playwright, expect
 
 
@@ -31,20 +32,19 @@ def sentry_api_request_context(
 def test_sentry_script_is_injected(
     sentry_api_request_context: APIRequestContext,
 ) -> None:
-    """With SENTRY_DSN set, the pinned bundle and its SRI hash are on the page."""
+    """With SENTRY_DSN and SENTRY_LOADER_URL set, the loader script is on the page.
+
+    The loader's own URL has a DSN baked in server-side -- it is unrelated
+    to, and does not have to match, the dummy SENTRY_DSN this app instance
+    was started with.
+    """
     body = sentry_api_request_context.get("/").text()
-    assert "browser.sentry-cdn.com" in body
-    assert 'integrity="sha384-' in body
-    assert "SENTRY_E2E_DSN" not in body  # sanity: the literal value, not the name
+    assert SENTRY_E2E_LOADER_URL in body
 
 
 @pytest.mark.skipif(
     os.environ.get("E2E_SENTRY_WIDGET") != "1",
-    reason=(
-        "loads the real Sentry SDK from its CDN -- opt in with "
-        "E2E_SENTRY_WIDGET=1. Also requires monitoring.SENTRY_SDK_VERSION/"
-        "SENTRY_SDK_SRI to be filled in with real values first."
-    ),
+    reason="loads the real Sentry SDK from its CDN -- opt in with E2E_SENTRY_WIDGET=1",
 )
 def test_feedback_widget_button_appears(
     playwright: Playwright,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,6 +10,10 @@ Re-record with::
 """
 
 import pytest
+import sentry_sdk
+from sentry_sdk.transport import Transport
+
+import monitoring
 
 
 @pytest.fixture(scope="module")
@@ -19,3 +23,51 @@ def vcr_config():
         "filter_headers": ["authorization", "cookie", "user-agent"],
         "decode_compressed_response": True,
     }
+
+
+class _CaptureTransport(Transport):
+    """Collects captured events in-process, with no network call.
+
+    A plain callable would work too, but sentry-sdk 2.x deprecates function
+    transports with a warning, and ``filterwarnings = ["error"]`` turns that
+    into a test failure.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def capture_envelope(self, envelope):
+        event = envelope.get_event()
+        if event is not None:
+            self.events.append(event)
+
+
+@pytest.fixture
+def sentry_events(monkeypatch):
+    """A list that fills with events captured by a throwaway Sentry client.
+
+    Resets monitoring's per-process init guards so ``init_sentry()`` can be
+    exercised fresh in each test, and tears the client back down afterwards so
+    tests do not leak a client into one another.
+    """
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+    monkeypatch.delenv("SENTRY_TRACES_SAMPLE_RATE", raising=False)
+    monkeypatch.setattr(monitoring._state, "initialised_pid", None)
+    monkeypatch.setattr(monitoring._state, "hook_installed", False)
+
+    transport = _CaptureTransport()
+    options = monitoring.sentry_options(
+        monitoring.Settings(dsn="https://public@example.invalid/1", environment="test"),
+    )
+    options["transport"] = transport
+    sentry_sdk.init(**options)
+    try:
+        yield transport.events
+    finally:
+        # sentry_sdk.init(dsn="") still constructs a real, "active" client --
+        # only clearing the scope's client puts the SDK back into its
+        # pre-init, disabled state for the next test.
+        sentry_sdk.get_global_scope().set_client(None)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -308,10 +308,44 @@ def test_admonition_offers_no_report_link_without_a_dsn(monkeypatch):
 
 def test_admonition_offers_a_report_link_for_errors_with_a_dsn(monkeypatch):
     monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.setenv(
+        "SENTRY_LOADER_URL",
+        "https://js.sentry-cdn.com/testtesttesttesttesttesttest0000.min.js",
+    )
 
     rendered = common.admonition("oops", kind="error").text
 
     assert "data-sentry-report" in rendered
+
+
+def test_admonition_offers_no_report_link_with_a_dsn_but_no_loader_url(monkeypatch):
+    """Both are required -- see monitoring.enabled()."""
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.delenv("SENTRY_LOADER_URL", raising=False)
+
+    rendered = common.admonition("oops", kind="error").text
+
+    assert "data-sentry-report" not in rendered
+
+
+def test_admonition_with_a_report_link_still_parses_as_a_directive(monkeypatch):
+    """Regression test: the report link used to be appended on its own line,
+    which starts at column 0 while every other line sits at this function's
+    source indentation. mo.md() dedents via inspect.cleandoc(), which strips
+    the *smallest* common leading whitespace across all lines -- one line at
+    column 0 drops that common amount to zero, so the ///-fenced lines keep
+    their original indentation and fail to parse as a directive at all,
+    rendering literally instead of as a styled admonition box."""
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.setenv(
+        "SENTRY_LOADER_URL",
+        "https://js.sentry-cdn.com/testtesttesttesttesttesttest0000.min.js",
+    )
+
+    rendered = common.admonition("oops", title="Oops", kind="error").text
+
+    assert '<div class="admonition error">' in rendered
+    assert "///" not in rendered
 
 
 def test_admonition_never_offers_a_report_link_for_non_errors(monkeypatch):

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -267,7 +267,10 @@ def test_load_ts_from_erddap_raises_for_a_dataset_that_is_not_there(sentry_event
     this failure has to be caught as well as the transport ones."""
     missing = {**NDBC_SST, "dataset": "gov-ndbc-does-not-exist"}
 
-    with pytest.raises(common.ErddapLoadError, match="gov-ndbc-does-not-exist"):
+    with pytest.raises(
+        common.ErddapLoadError,
+        match="gov-ndbc-does-not-exist",
+    ) as excinfo:
         common.load_ts_from_erddap(missing)
 
     # Every caller of load_ts_from_erddap handles ErddapLoadError, so it is
@@ -278,6 +281,17 @@ def test_load_ts_from_erddap_raises_for_a_dataset_that_is_not_there(sentry_event
     assert event["level"] == "warning"
     assert event["fingerprint"] == ["erddap-load", NDBC_SST["server"]]
     assert event["tags"]["dataset"] == "gov-ndbc-does-not-exist"
+
+    # Carried on the exception so a caller can offer it back to
+    # common.admonition(sentry_event_id=...) and let a feedback submission be
+    # linked to this exact event.
+    assert excinfo.value.sentry_event_id == event["event_id"]
+
+    # And the reported event's trace matches the load's own span, rather than
+    # a fresh, disconnected one -- see monitoring.report()'s docstring for why
+    # that depends on reporting from inside the span, not after it has closed.
+    assert event["contexts"]["trace"]["op"] == "http.client"
+    assert "gov-ndbc-does-not-exist" in event["transaction"]
 
 
 @pytest.mark.vcr
@@ -366,3 +380,35 @@ def test_admonition_report_can_be_forced_on_and_off(monkeypatch):
         "data-sentry-report"
         not in common.admonition("x", kind="attention", report=False).text
     )
+
+
+def test_admonition_embeds_a_valid_sentry_event_id():
+    """A real Sentry event id is 32 lowercase hex characters."""
+    rendered = common.admonition(
+        "x",
+        kind="error",
+        report=True,
+        sentry_event_id="4a99b1f0c54b4b248939e08c6485e90d",
+    ).text
+
+    assert 'data-sentry-event-id="4a99b1f0c54b4b248939e08c6485e90d"' in rendered
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "not-a-real-event-id",
+        '4a99b1f0c54b4b248939e08c6485e90d"><script>alert(1)</script>',
+    ],
+)
+def test_admonition_omits_a_missing_or_malformed_sentry_event_id(value):
+    rendered = common.admonition(
+        "x",
+        kind="error",
+        report=True,
+        sentry_event_id=value,
+    ).text
+
+    assert "data-sentry-event-id" not in rendered

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -6,6 +6,7 @@ conftest.py.
 
 import pandas as pd
 import pytest
+import sentry_sdk
 
 import common
 
@@ -261,13 +262,22 @@ def test_load_ts_from_erddap_returns_the_requested_timeseries():
 
 
 @pytest.mark.vcr
-def test_load_ts_from_erddap_raises_for_a_dataset_that_is_not_there():
+def test_load_ts_from_erddap_raises_for_a_dataset_that_is_not_there(sentry_events):
     """ERDDAP answers a rejected request with a body pandas cannot parse, so
     this failure has to be caught as well as the transport ones."""
     missing = {**NDBC_SST, "dataset": "gov-ndbc-does-not-exist"}
 
     with pytest.raises(common.ErddapLoadError, match="gov-ndbc-does-not-exist"):
         common.load_ts_from_erddap(missing)
+
+    # Every caller of load_ts_from_erddap handles ErddapLoadError, so it is
+    # reported here, before the wrap, or it would never reach Sentry at all.
+    sentry_sdk.flush()
+    assert len(sentry_events) == 1
+    event = sentry_events[0]
+    assert event["level"] == "warning"
+    assert event["fingerprint"] == ["erddap-load", NDBC_SST["server"]]
+    assert event["tags"]["dataset"] == "gov-ndbc-does-not-exist"
 
 
 @pytest.mark.vcr
@@ -286,3 +296,39 @@ def test_load_ts_hands_back_a_fresh_frame_each_call():
     second = common.load_ts(NDBC_SST, "Sea Surface Temperature")
 
     assert "Sea Surface Temperature" in second.columns
+
+
+def test_admonition_offers_no_report_link_without_a_dsn(monkeypatch):
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    rendered = common.admonition("oops", kind="error").text
+
+    assert "data-sentry-report" not in rendered
+
+
+def test_admonition_offers_a_report_link_for_errors_with_a_dsn(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+
+    rendered = common.admonition("oops", kind="error").text
+
+    assert "data-sentry-report" in rendered
+
+
+def test_admonition_never_offers_a_report_link_for_non_errors(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+
+    rendered = common.admonition("", kind="attention").text
+
+    assert "data-sentry-report" not in rendered
+
+
+def test_admonition_report_can_be_forced_on_and_off(monkeypatch):
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    assert (
+        "data-sentry-report" in common.admonition("x", kind="error", report=True).text
+    )
+    assert (
+        "data-sentry-report"
+        not in common.admonition("x", kind="attention", report=False).text
+    )

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -85,7 +85,7 @@ def test_sentry_options_carries_environment_and_release():
 
 def test_traces_sampler_drops_health_checks():
     rate = monitoring._traces_sampler(
-        {"asgi_scope": {"type": "http", "path": "/health"}}
+        {"asgi_scope": {"type": "http", "path": "/health"}},
     )
     assert rate == 0.0
 
@@ -119,7 +119,9 @@ def test_traces_sampler_uses_the_configured_rate_for_everything_else(monkeypatch
 
 def test_mo_stop_is_not_reported(sentry_events):
     monitoring._capture_cell_exception(
-        FakeCell(), None, FakeRunResult(MarimoStopError(None))
+        FakeCell(),
+        None,
+        FakeRunResult(MarimoStopError(None)),
     )
     sentry_sdk.flush()
     assert sentry_events == []
@@ -128,7 +130,9 @@ def test_mo_stop_is_not_reported(sentry_events):
 def test_an_interrupt_is_not_reported(sentry_events):
     """MarimoInterrupt is an alias for KeyboardInterrupt."""
     monitoring._capture_cell_exception(
-        FakeCell(), None, FakeRunResult(MarimoInterrupt())
+        FakeCell(),
+        None,
+        FakeRunResult(MarimoInterrupt()),
     )
     sentry_sdk.flush()
     assert sentry_events == []
@@ -234,45 +238,89 @@ def test_the_post_execution_hook_signature_is_still_three_arguments():
 
 # --- html_head ---------------------------------------------------------
 
+FAKE_DSN = "https://public@example.invalid/1"
+FAKE_LOADER_URL = "https://js.sentry-cdn.com/testtesttesttesttesttesttest0000.min.js"
+
+
+def _configure(monkeypatch, *, dsn=FAKE_DSN, loader_url=FAKE_LOADER_URL):
+    """Set (or, with None, unset) SENTRY_DSN and SENTRY_LOADER_URL together --
+    html_head() and enabled() both require both."""
+    for name, value in (("SENTRY_DSN", dsn), ("SENTRY_LOADER_URL", loader_url)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
 
 @pytest.mark.parametrize("value", ["", "   ", None])
 def test_html_head_is_none_without_a_dsn(monkeypatch, value):
-    if value is None:
-        monkeypatch.delenv("SENTRY_DSN", raising=False)
-    else:
-        monkeypatch.setenv("SENTRY_DSN", value)
+    _configure(monkeypatch, dsn=value)
 
     assert monitoring.html_head() is None
 
 
-def test_html_head_rejects_a_non_https_dsn(monkeypatch, caplog):
-    monkeypatch.setenv("SENTRY_DSN", "not-a-dsn")
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_html_head_is_none_without_a_loader_url(monkeypatch, value):
+    _configure(monkeypatch, loader_url=value)
 
     assert monitoring.html_head() is None
-    assert "SENTRY_DSN" in caplog.text
 
 
-def test_html_head_contains_the_pinned_bundle_and_no_defer_or_async(monkeypatch):
-    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+def test_html_head_rejects_a_non_https_loader_url(monkeypatch, caplog):
+    _configure(monkeypatch, loader_url="not-a-url")
+
+    assert monitoring.html_head() is None
+    assert "SENTRY_LOADER_URL" in caplog.text
+
+
+def test_loader_url_env_accepts_the_whole_script_tag(monkeypatch):
+    """Sentry's dashboard hands this out as a whole <script src="...">
+    tag under the literal heading "Loader Script" -- pasting that as-is into
+    SENTRY_LOADER_URL, rather than picking the URL back out of it, is the
+    natural mistake to make. This is a real production incident: see the
+    conversation this test was added from."""
+    monkeypatch.setenv(
+        "SENTRY_LOADER_URL",
+        '<script src="https://js.sentry-cdn.com/abc123.min.js" '
+        'crossorigin="anonymous"></script>',
+    )
+
+    assert (
+        monitoring.Settings.from_env().loader_url
+        == "https://js.sentry-cdn.com/abc123.min.js"
+    )
+
+
+def test_html_head_contains_the_loader_script_and_no_defer_or_async(monkeypatch):
+    _configure(monkeypatch)
 
     head = monitoring.html_head()
 
-    assert monitoring.SENTRY_SDK_URL in head
-    assert f'integrity="{monitoring.SENTRY_SDK_SRI}"' in head
+    assert FAKE_LOADER_URL in head
     script_tag = re.search(r"<script src=.*?</script>", head).group()
     assert "defer" not in script_tag
     assert "async" not in script_tag
 
 
+def test_html_head_does_not_embed_the_dsn(monkeypatch):
+    """The loader URL has a DSN baked in server-side already; SENTRY_DSN here
+    only toggles whether the snippet is injected at all, and may even name a
+    different Sentry project (see README.md's local-testing note)."""
+    _configure(monkeypatch)
+
+    head = monitoring.html_head()
+
+    assert FAKE_DSN not in head
+
+
 def test_html_head_options_round_trip(monkeypatch):
-    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    _configure(monkeypatch)
     monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
     monkeypatch.setenv("SENTRY_RELEASE", "abc123")
 
     head = monitoring.html_head()
     options = json.loads(re.search(r"var options = (\{.*?\});", head, re.S).group(1))
 
-    assert options["dsn"] == "https://public@example.invalid/1"
     assert options["environment"] == "test"
     assert options["release"] == "abc123"
     assert options["sendDefaultPii"] is False
@@ -281,7 +329,7 @@ def test_html_head_options_round_trip(monkeypatch):
 
 
 def test_html_head_omits_environment_and_release_when_unset(monkeypatch):
-    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    _configure(monkeypatch)
     monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
     monkeypatch.delenv("SENTRY_RELEASE", raising=False)
 
@@ -292,11 +340,13 @@ def test_html_head_omits_environment_and_release_when_unset(monkeypatch):
     assert "release" not in options
 
 
-def test_html_head_neutralises_a_dsn_containing_a_closing_script_tag(monkeypatch):
-    monkeypatch.setenv(
-        "SENTRY_DSN",
-        'https://public@example.invalid/1"; </script><script>alert(1)//',
-    )
+def test_html_head_neutralises_an_environment_containing_a_closing_script_tag(
+    monkeypatch,
+):
+    """SENTRY_DSN no longer reaches the page (see test_html_head_does_not_embed_the_dsn),
+    but SENTRY_ENVIRONMENT still does, so it is what exercises the escaping."""
+    _configure(monkeypatch)
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", '"; </script><script>alert(1)//')
 
     head = monitoring.html_head()
 
@@ -305,10 +355,14 @@ def test_html_head_neutralises_a_dsn_containing_a_closing_script_tag(monkeypatch
 
 
 def test_enabled_agrees_with_html_head(monkeypatch):
-    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    _configure(monkeypatch, dsn=None, loader_url=None)
     assert monitoring.enabled() is False
     assert monitoring.html_head() is None
 
-    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    _configure(monkeypatch, dsn=FAKE_DSN, loader_url=None)
+    assert monitoring.enabled() is False
+    assert monitoring.html_head() is None
+
+    _configure(monkeypatch)
     assert monitoring.enabled() is True
     assert monitoring.html_head() is not None

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -211,6 +211,37 @@ def test_report_defaults_to_error_level(sentry_events):
     assert sentry_events[0]["level"] == "error"
 
 
+def test_report_returns_the_event_id(sentry_events):
+    """The returned id is what lets a caller offer the event back to the
+    browser -- see common.admonition()'s sentry_event_id -- so a feedback
+    submission can be linked to it."""
+    try:
+        msg = "erddap is down"
+        raise RuntimeError(msg)
+    except RuntimeError as error:
+        event_id = monitoring.report(error, where="erddap.load_ts")
+    sentry_sdk.flush()
+
+    assert event_id == sentry_events[0]["event_id"]
+
+
+def test_report_from_inside_an_active_span_inherits_its_trace(sentry_events):
+    """Reporting from *outside* the span that failed (after its `with` block
+    has already exited) would give the event an unrelated trace_id -- see
+    common.load_ts_from_erddap and calculate_datums.py, which both report
+    from inside the span for exactly this reason."""
+    with monitoring.operation("erddap test-dataset", op="http.client") as span:
+        trace_id = span.trace_id
+        try:
+            msg = "erddap is down"
+            raise RuntimeError(msg)
+        except RuntimeError as error:
+            monitoring.report(error, where="erddap.load_ts")
+    sentry_sdk.flush()
+
+    assert sentry_events[0]["contexts"]["trace"]["trace_id"] == trace_id
+
+
 # --- marimo upgrade canaries ------------------------------------------------
 #
 # These walk the same private chain install_marimo_hook() depends on. If a

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,314 @@
+"""Unit tests for the Sentry wiring.
+
+No test here needs a network connection or a real Sentry project: the
+``sentry_events`` fixture (see conftest.py) installs a throwaway client backed
+by an in-process transport, and everything else is a pure function of
+environment variables or of objects built by hand.
+"""
+
+import inspect
+import json
+import re
+
+import pytest
+import sentry_sdk
+from marimo._messaging.errors import MarimoAncestorStoppedError
+from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
+from marimo._runtime.runner import hooks_post_execution
+from marimo._runtime.runner.hooks import create_default_hooks
+
+import monitoring
+
+
+class FakeCell:
+    def __init__(self, cell_id="abc"):
+        self.cell_id = cell_id
+
+
+class FakeRunResult:
+    def __init__(self, exception):
+        self.exception = exception
+
+
+# --- init_sentry ------------------------------------------------------------
+
+
+def test_init_sentry_is_a_noop_without_a_dsn(monkeypatch):
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    sentry_sdk.get_global_scope().set_client(None)
+
+    assert monitoring.init_sentry() is False
+    assert sentry_sdk.get_client().is_active() is False
+
+
+def test_init_sentry_is_idempotent_per_process(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.setattr(monitoring._state, "initialised_pid", None)
+    monkeypatch.setattr(monitoring._state, "hook_installed", False)
+
+    try:
+        assert monitoring.init_sentry() is True
+        client = sentry_sdk.get_client()
+        assert monitoring.init_sentry() is True
+        assert sentry_sdk.get_client() is client
+    finally:
+        sentry_sdk.get_global_scope().set_client(None)
+
+
+# --- sentry_options -----------------------------------------------------
+
+
+def test_sentry_options_disables_pii_and_request_bodies():
+    options = monitoring.sentry_options(
+        monitoring.Settings(dsn="https://public@example.invalid/1"),
+    )
+
+    assert options["send_default_pii"] is False
+    assert options["max_request_body_size"] == "never"
+
+
+def test_sentry_options_carries_environment_and_release():
+    options = monitoring.sentry_options(
+        monitoring.Settings(
+            dsn="https://public@example.invalid/1",
+            environment="staging",
+            release="abc123",
+        ),
+    )
+
+    assert options["environment"] == "staging"
+    assert options["release"] == "abc123"
+
+
+# --- _traces_sampler ------------------------------------------------------
+
+
+def test_traces_sampler_drops_health_checks():
+    rate = monitoring._traces_sampler(
+        {"asgi_scope": {"type": "http", "path": "/health"}}
+    )
+    assert rate == 0.0
+
+
+def test_traces_sampler_drops_static_assets():
+    rate = monitoring._traces_sampler(
+        {"asgi_scope": {"type": "http", "path": "/assets/index.js"}},
+    )
+    assert rate == 0.0
+
+
+def test_traces_sampler_drops_websockets():
+    """One websocket per open browser tab, held for the tab's whole life --
+    sampling those would produce hours-long, span-less transactions."""
+    rate = monitoring._traces_sampler(
+        {"asgi_scope": {"type": "websocket", "path": "/ws"}},
+    )
+    assert rate == 0.0
+
+
+def test_traces_sampler_uses_the_configured_rate_for_everything_else(monkeypatch):
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.4")
+    rate = monitoring._traces_sampler(
+        {"asgi_scope": {"type": "http", "path": "/climatology"}},
+    )
+    assert rate == 0.4
+
+
+# --- _capture_cell_exception ----------------------------------------------
+
+
+def test_mo_stop_is_not_reported(sentry_events):
+    monitoring._capture_cell_exception(
+        FakeCell(), None, FakeRunResult(MarimoStopError(None))
+    )
+    sentry_sdk.flush()
+    assert sentry_events == []
+
+
+def test_an_interrupt_is_not_reported(sentry_events):
+    """MarimoInterrupt is an alias for KeyboardInterrupt."""
+    monitoring._capture_cell_exception(
+        FakeCell(), None, FakeRunResult(MarimoInterrupt())
+    )
+    sentry_sdk.flush()
+    assert sentry_events == []
+
+
+def test_a_marimo_error_dataclass_is_not_reported(sentry_events):
+    """Cascade notices ("an ancestor raised...") are dataclasses, not
+    exceptions, so they are excluded before the control-flow check even runs."""
+    cascade = MarimoAncestorStoppedError(msg="stopped", raising_cell="cell-1")
+    monitoring._capture_cell_exception(FakeCell(), None, FakeRunResult(cascade))
+    sentry_sdk.flush()
+    assert sentry_events == []
+
+
+def test_a_real_cell_exception_is_reported(sentry_events):
+    try:
+        msg = "boom"
+        raise ValueError(msg)
+    except ValueError as error:
+        monitoring._capture_cell_exception(
+            FakeCell(cell_id="cell-42"),
+            None,
+            FakeRunResult(error),
+        )
+    sentry_sdk.flush()
+
+    assert len(sentry_events) == 1
+    event = sentry_events[0]
+    assert event["exception"]["values"][0]["type"] == "ValueError"
+    assert event["tags"]["marimo.cell_id"] == "cell-42"
+    assert "marimo.page" in event["tags"]
+
+
+def test_the_hook_never_raises_on_a_malformed_run_result(sentry_events):
+    class Weird:
+        pass
+
+    monitoring._capture_cell_exception(FakeCell(), None, Weird())
+    sentry_sdk.flush()
+    assert sentry_events == []
+
+
+# --- report() ---------------------------------------------------------------
+
+
+def test_report_sets_level_fingerprint_and_tags(sentry_events):
+    try:
+        msg = "erddap is down"
+        raise RuntimeError(msg)
+    except RuntimeError as error:
+        monitoring.report(
+            error,
+            where="erddap.load_ts",
+            level="warning",
+            fingerprint=["erddap-load", "https://data.neracoos.org/erddap"],
+            dataset="A01_met_all",
+        )
+    sentry_sdk.flush()
+
+    assert len(sentry_events) == 1
+    event = sentry_events[0]
+    assert event["level"] == "warning"
+    assert event["fingerprint"] == ["erddap-load", "https://data.neracoos.org/erddap"]
+    assert event["tags"]["where"] == "erddap.load_ts"
+    assert event["tags"]["dataset"] == "A01_met_all"
+
+
+def test_report_defaults_to_error_level(sentry_events):
+    try:
+        msg = "tadc blew up"
+        raise RuntimeError(msg)
+    except RuntimeError as error:
+        monitoring.report(error, where="calculate_datums.tadc_run")
+    sentry_sdk.flush()
+
+    assert sentry_events[0]["level"] == "error"
+
+
+# --- marimo upgrade canaries ------------------------------------------------
+#
+# These walk the same private chain install_marimo_hook() depends on. If a
+# marimo upgrade moves any of it, these fail loudly in CI instead of
+# notebook cell errors silently going unreported in production.
+
+
+def test_marimo_still_exposes_the_post_execution_hook_list():
+    assert isinstance(hooks_post_execution.POST_EXECUTION_HOOKS, list)
+
+
+def test_our_hook_reaches_the_hooks_new_kernels_are_built_from(monkeypatch):
+    monkeypatch.setattr(monitoring._state, "hook_installed", False)
+    assert monitoring.install_marimo_hook() is True
+    assert (
+        monitoring._capture_cell_exception
+        in create_default_hooks().post_execution_hooks
+    )
+
+
+def test_the_post_execution_hook_signature_is_still_three_arguments():
+    hook = hooks_post_execution.POST_EXECUTION_HOOKS[0]
+    assert len(inspect.signature(hook).parameters) == 3
+
+
+# --- html_head ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_html_head_is_none_without_a_dsn(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv("SENTRY_DSN", raising=False)
+    else:
+        monkeypatch.setenv("SENTRY_DSN", value)
+
+    assert monitoring.html_head() is None
+
+
+def test_html_head_rejects_a_non_https_dsn(monkeypatch, caplog):
+    monkeypatch.setenv("SENTRY_DSN", "not-a-dsn")
+
+    assert monitoring.html_head() is None
+    assert "SENTRY_DSN" in caplog.text
+
+
+def test_html_head_contains_the_pinned_bundle_and_no_defer_or_async(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+
+    head = monitoring.html_head()
+
+    assert monitoring.SENTRY_SDK_URL in head
+    assert f'integrity="{monitoring.SENTRY_SDK_SRI}"' in head
+    script_tag = re.search(r"<script src=.*?</script>", head).group()
+    assert "defer" not in script_tag
+    assert "async" not in script_tag
+
+
+def test_html_head_options_round_trip(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    monkeypatch.setenv("SENTRY_RELEASE", "abc123")
+
+    head = monitoring.html_head()
+    options = json.loads(re.search(r"var options = (\{.*?\});", head, re.S).group(1))
+
+    assert options["dsn"] == "https://public@example.invalid/1"
+    assert options["environment"] == "test"
+    assert options["release"] == "abc123"
+    assert options["sendDefaultPii"] is False
+    assert options["replaysSessionSampleRate"] == 0
+    assert options["replaysOnErrorSampleRate"] == 1.0
+
+
+def test_html_head_omits_environment_and_release_when_unset(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+
+    head = monitoring.html_head()
+    options = json.loads(re.search(r"var options = (\{.*?\});", head, re.S).group(1))
+
+    assert "environment" not in options
+    assert "release" not in options
+
+
+def test_html_head_neutralises_a_dsn_containing_a_closing_script_tag(monkeypatch):
+    monkeypatch.setenv(
+        "SENTRY_DSN",
+        'https://public@example.invalid/1"; </script><script>alert(1)//',
+    )
+
+    head = monitoring.html_head()
+
+    options_blob = head.split("var options = ", 1)[1].split(";\n", 1)[0]
+    assert "</script>" not in options_blob
+
+
+def test_enabled_agrees_with_html_head(monkeypatch):
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    assert monitoring.enabled() is False
+    assert monitoring.html_head() is None
+
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
+    assert monitoring.enabled() is True
+    assert monitoring.html_head() is not None


### PR DESCRIPTION
Adds a new monitoring.py module that wires up Sentry: backend errors
and traces via sentry_sdk, plus a browser-side script (injected through
marimo's html_head) carrying the feedback widget and on-error session
replay. Everything is a no-op unless SENTRY_DSN is set, so local runs,
the devcontainer, and CI are unaffected.

Since marimo never routes a notebook cell's exception through logging,
a guarded hook is appended to marimo's post-execution hooks so cell
errors are actually captured; canary tests make a marimo upgrade that
breaks this fail CI instead of silently disabling error reporting.
ERDDAP failures and two previously-silent bare excepts in
calculate_datums.py are also reported explicitly, and error admonitions
gain an optional "tell us what you were doing" link into the feedback
form.

Resolves #133.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WUXBmWzGzeiJw8wiuR5Dps