### PR TITLE
Concatenate platform id and station name in pickers (#157)

### DIFF
--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -47,7 +47,7 @@ def _(platform_json):
         for _ts in _platform["properties"]["readings"]:
             _standard_name = _ts["data_type"]["standard_name"]
             standards[_standard_name] = _ts["data_type"]
-            _name = f"{_platform['id']}"
+            _name = common.platform_display_name(_platform)
             if _ts["depth"]:
                 _name = _name + f" - {_ts['depth']}"
             platform_standards.setdefault(_standard_name, {})[_name] = _ts

--- a/common.py
+++ b/common.py
@@ -115,11 +115,18 @@ def load_platform_json(visibility: str | None = None):
         return platforms
 
 
+def platform_display_name(feature: dict) -> str:
+    """A platform's id, plus its station name when it has one, e.g. "A01 - Mass Bay"."""
+    station_name = feature["properties"]["station_name"]
+    if station_name:
+        return f"{feature['id']} - {station_name}"
+    return feature["id"]
+
+
 def platforms_by_name(platform_json: dict) -> dict:
-    """Platform features keyed by station name, falling back to id, sorted."""
+    """Platform features keyed by "id - station name" (or bare id), sorted."""
     platforms = {
-        feature["properties"]["station_name"] or feature["id"]: feature
-        for feature in platform_json["features"]
+        platform_display_name(feature): feature for feature in platform_json["features"]
     }
     return dict(sorted(platforms.items()))
 

--- a/tests/e2e/test_by_platform.py
+++ b/tests/e2e/test_by_platform.py
@@ -6,7 +6,9 @@ def test_western_maine_shelf(page: Page) -> None:
     page.goto("/")
     page.get_by_role("navigation").get_by_role("link", name="By Buoy").click()
     expect(page).to_have_url("/by_platform/")
-    page.get_by_test_id("marimo-plugin-dropdown").select_option("Western Maine Shelf")
+    page.get_by_test_id("marimo-plugin-dropdown").select_option(
+        "B01 - Western Maine Shelf",
+    )
     page.get_by_text("Select...").click()
     page.get_by_role("option", name="Air Temperature").click()
     page.get_by_role("option", name="Barometric Pressure").click()

--- a/tests/e2e/test_climatology.py
+++ b/tests/e2e/test_climatology.py
@@ -10,10 +10,10 @@ def test_western_maine_shelf_air(page: Page) -> None:
     page.goto("/")
     page.get_by_role("navigation").get_by_role("link", name="Climatology").click()
     expect(page).to_have_url("/climatology/")
-    page.get_by_label("Platform").select_option("Western Maine Shelf")
+    page.get_by_label("Platform").select_option("B01 - Western Maine Shelf")
     page.get_by_label("Data Type").select_option("Air Temperature")
     expect(page).to_have_url(
-        "/climatology/?platform=Western+Maine+Shelf&ts=Air+Temperature",
+        "/climatology/?platform=B01+-+Western+Maine+Shelf&ts=Air+Temperature",
     )
 
     assert_chart_rendered(page)
@@ -24,7 +24,7 @@ def test_western_maine_shelf_air(page: Page) -> None:
 def test_monthly_averaging_period(page: Page) -> None:
     """Monthly used to die on `clim_df["Date"]` after that column was renamed
     to "Month", so the whole averaging period was unreachable."""
-    page.goto("/climatology/?platform=Western+Maine+Shelf&ts=Air+Temperature")
+    page.goto("/climatology/?platform=B01+-+Western+Maine+Shelf&ts=Air+Temperature")
     page.get_by_label("Averaging Time Period").select_option("Monthly")
 
     assert_chart_rendered(page)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -83,9 +83,19 @@ def test_platforms_by_name_prefers_the_station_name_and_sorts():
 
     platforms = common.platforms_by_name(platform_json)
 
-    assert list(platforms) == ["44007", "Western Maine Shelf"]
+    assert list(platforms) == ["44005 - Western Maine Shelf", "44007"]
     assert platforms["44007"]["id"] == "44007"
-    assert platforms["Western Maine Shelf"]["id"] == "44005"
+    assert platforms["44005 - Western Maine Shelf"]["id"] == "44005"
+
+
+def test_platform_display_name_concatenates_id_and_station_name():
+    feature = {"id": "A01", "properties": {"station_name": "Mass Bay"}}
+    assert common.platform_display_name(feature) == "A01 - Mass Bay"
+
+
+def test_platform_display_name_falls_back_to_id_only():
+    feature = {"id": "44007", "properties": {"station_name": None}}
+    assert common.platform_display_name(feature) == "44007"
 
 
 def test_timeseries_by_name_sorts_and_records_the_app_name():


### PR DESCRIPTION
Platform dropdowns on By Platform and Climatology showed only the human
station name (e.g. "Mass Bay"), ambiguous without the short code used
elsewhere in the NERACOOS ecosystem. Add common.platform_display_name()
to build "id - station name" (falling back to bare id when there's no
name), and use it for platforms_by_name() and By Standard Name's
per-timeseries picker, so all platform pickers now show e.g.
"B01 - Western Maine Shelf".

Closes #157 

Assisted-by: claude-code:sonnet