### PR TITLE
Handle empty ERDDAP datasets and tag Sentry context across pages

### DIFF
--- a/by_platform.py
+++ b/by_platform.py
@@ -74,9 +74,18 @@ def _(platform_selector, time_series_selector):
 
 
 @app.cell
-def _(time_series_selector):
+def _(platform_selector, time_series_selector):
     loaded_ts = {}
     unit_ts = {}
+
+    if platform_selector.value:
+        monitoring.tag_context(platform=platform_selector.value["id"])
+    if time_series_selector.value:
+        monitoring.tag_context(
+            timeseries=",".join(
+                sorted(common.name_for_ts(_ts) for _ts in time_series_selector.value),
+            ),
+        )
 
     with mo.status.spinner(title="Loading data from ERDDAP"):
         for _ts in time_series_selector.value:

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -138,8 +138,13 @@ def _(selected_ts_keys):
 
 
 @app.cell
-def _(platform_options, selected_ts_keys, unit):
+def _(platform_options, selected_ts_keys, standard_name_dropdown, unit):
     _wide_dfs = []
+
+    if standard_name_dropdown.value:
+        monitoring.tag_context(standard_name=standard_name_dropdown.value)
+    if selected_ts_keys.value:
+        monitoring.tag_context(platforms=",".join(sorted(selected_ts_keys.value)))
 
     try:
         with mo.status.spinner(title="Loading data from ERDDAP"):

--- a/calculate_datums.py
+++ b/calculate_datums.py
@@ -92,6 +92,7 @@ def _(common, dataset_id, erddapy, mo, monitoring, use_qartod):
             kind="warning",
         ),
     )
+    monitoring.tag_context(dataset=dataset_id, qartod=str(use_qartod.value))
     e = erddapy.ERDDAP(
         server="https://data.neracoos.org/erddap",
         protocol="tabledap",

--- a/climatology.py
+++ b/climatology.py
@@ -103,7 +103,7 @@ def _(platform):
 
 
 @app.cell
-def _(timeseries_dropdown):
+def _(platform, timeseries_dropdown):
     ts = timeseries_dropdown.value
     if ts is None:
         mo.stop(
@@ -114,6 +114,7 @@ def _(timeseries_dropdown):
                 kind="warning",
             ),
         )
+    monitoring.tag_context(platform=platform["id"], dataset=ts["app_name"])
     return (ts,)
 
 
@@ -140,6 +141,15 @@ def _(df_all):
     df_no_index = df_all.reset_index()
     df_no_index = df_no_index.rename({"time (UTC)": core.TIME_COLUMN}, axis=1)
     column = df_all.columns[0]
+    if df_no_index.empty:
+        mo.stop(
+            True,
+            common.admonition(
+                "",
+                title="No data available for the selected platform and data type",
+                kind="warning",
+            ),
+        )
     return column, df_no_index
 
 
@@ -210,7 +220,13 @@ def _(query_params):
 
 
 @app.cell
-def _(average_period_dropdown, end_year_dropdown, start_year_dropdown):
+def _(average_period_dropdown, end_year_dropdown, start_year_dropdown, year_dropdown):
+    monitoring.tag_context(
+        year=year_dropdown.value,
+        clim_start=start_year_dropdown.value,
+        clim_end=end_year_dropdown.value,
+        avg_period=average_period_dropdown.value,
+    )
     mo.hstack([start_year_dropdown, end_year_dropdown, average_period_dropdown])
 
 

--- a/monitoring.py
+++ b/monitoring.py
@@ -287,6 +287,18 @@ def tag_page(page: str) -> None:
     sentry_sdk.get_isolation_scope().set_tag("marimo.page", page)
 
 
+def tag_context(**tags: str) -> None:
+    """Tag every subsequent event from this kernel thread with arbitrary
+    page-specific context (e.g. the platform, dataset, or year a page is
+    currently showing). Like tag_page(), this persists on the thread's
+    isolation scope across cell reruns until overwritten -- call again
+    whenever a relevant value changes.
+    """
+    scope = sentry_sdk.get_isolation_scope()
+    for key, value in tags.items():
+        scope.set_tag(key, value)
+
+
 def _page_name() -> str:
     tagged = getattr(_page, "name", None)
     if tagged:

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -175,6 +175,37 @@ def test_the_hook_never_raises_on_a_malformed_run_result(sentry_events):
     assert sentry_events == []
 
 
+# --- tag_context() ----------------------------------------------------------
+
+
+def test_tag_context_lands_on_a_later_cell_exception(sentry_events):
+    monitoring.tag_context(platform="B01", dataset="Air Temperature")
+    try:
+        msg = "boom"
+        raise ValueError(msg)
+    except ValueError as error:
+        monitoring._capture_cell_exception(FakeCell(), None, FakeRunResult(error))
+    sentry_sdk.flush()
+
+    assert len(sentry_events) == 1
+    tags = sentry_events[0]["tags"]
+    assert tags["platform"] == "B01"
+    assert tags["dataset"] == "Air Temperature"
+
+
+def test_tag_context_overwrites_a_previous_value_for_the_same_key(sentry_events):
+    monitoring.tag_context(year="2023")
+    monitoring.tag_context(year="2024")
+    try:
+        msg = "boom"
+        raise ValueError(msg)
+    except ValueError as error:
+        monitoring._capture_cell_exception(FakeCell(), None, FakeRunResult(error))
+    sentry_sdk.flush()
+
+    assert sentry_events[0]["tags"]["year"] == "2024"
+
+
 # --- report() ---------------------------------------------------------------
 
 


### PR DESCRIPTION
An empty timeseries (e.g. a dead sensor, all-NaN after dropna()) crashed
two independent marimo cells in climatology.py with an IndexError (#158)
and a ValueError (#159), since neither guarded against the same empty
dataframe. Add one stop-early guard where both cells' shared dependency
is computed.

Also tag the Sentry scope with platform/dataset/year/period context as
they're resolved, on climatology.py and the other data pages, since
ThreadingIntegration(propagate_scope=False) means kernel cell exceptions
otherwise carry no request context to diagnose from.

Closes #158, Closes #159

Assisted-by: claude-code:claude-sonnet-5