### PR TITLE
Add pixi run kill-server to clear a stale dev server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,18 @@ cmd = "playwright show-trace {{trace_path}}"
 [tool.pixi.tasks]
 edit = "marimo edit"
 app = "marimo run climatology.py"
-# serve = "marimo run climatology.py --host 0.0.0.0 -p 8080 --base-url /climatology"
+
+# Granian ignores SIGTERM, and binds with SO_REUSEPORT so a second `pixi run
+# serve` on the same port doesn't fail to bind -- it silently shares the port
+# with the stale one instead, splitting requests between them and making the
+# app merely look hung. Uses `-sTCP:LISTEN` as a bare port match (e.g. `lsof
+# -ti:PORT` without it) also matches other processes' client connections to
+# the app -- a browser tab with the page open, say -- and killing those is
+# not what "clean up old servers" means.
+[tool.pixi.tasks.kill-server]
+args = [ { arg = "port", default = "8080" } ]
+cmd = "kill -9 $(lsof -nP -iTCP:{{ port }} -sTCP:LISTEN -t 2>/dev/null) 2>/dev/null || true"
+description = "Kill any process listening on the given port, if any. Useful for cleaning up old servers before starting a new one."
 
 # granian serves public/ itself, so requests for the logo never reach the app.
 # The route is absolute so it resolves identically from every sub-mounted
@@ -98,6 +109,7 @@ cmd = """\
   granian --interface asgi --host {{ host }} --port {{ port }} --access-log --static-path-route /static \
   --static-path-mount public app:app\
   """
+description = "Serve the app on the given host and port, with /static routed to public/."
 
 [tool.pixi.workspace]
 channels = [ "conda-forge" ]


### PR DESCRIPTION
pixi run serve's granian process ignores SIGTERM and binds with
SO_REUSEPORT, so a leftover instance doesn't fail to bind -- it silently
shares the port with a new one, splitting requests between them and making
the app merely look hung rather than failing loudly. 

`kill-server` finds and kill -9s only the LISTEN-ing PIDs on the port
(default 8080, overridable), never a bare port match, since that would
also catch other processes' client connections to the app -- a browser
tab with the page open, say -- which isn't what "clean up old servers"
means.

Assisted-by: claude-code:sonnet