### PR TITLE
Add bookmarkable query-param state for by_platform and by_standard_name

### DIFF
--- a/by_platform.py
+++ b/by_platform.py
@@ -45,10 +45,24 @@ def _(platform_json):
 
 
 @app.cell
-def _(platforms):
+def _():
+    query_params = mo.query_params()
+    return (query_params,)
+
+
+@app.cell
+def _(platforms, query_params):
+    _ids_to_names = {feature["id"]: name for name, feature in platforms.items()}
+    _default_name = _ids_to_names.get(query_params.get("platform"))
+
     platform_selector = mo.ui.dropdown(
         platforms,
         label="Select platform",
+        value=_default_name,
+        on_change=lambda value: query_params.set(
+            "platform",
+            value["id"] if value else None,
+        ),
     )
     return (platform_selector,)
 
@@ -60,10 +74,20 @@ def _(platform_selector):
 
 
 @app.cell
-def _(platform_time_series):
+def _(platform_time_series, query_params):
     time_series_selector = mo.ui.multiselect(
         platform_time_series,
         label="Select time series",
+        value=common.query_param_list_default(
+            query_params,
+            "ts",
+            platform_time_series,
+            fallback=[],
+        ),
+        on_change=lambda value: query_params.set(
+            "ts",
+            ",".join(v["app_name"] for v in value),
+        ),
     )
     return (time_series_selector,)
 

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -92,13 +92,20 @@ def _(platform_standards, query_params, standards):
 
 
 @app.cell
-def _(platform_standards, standard_name_dropdown):
+def _(platform_standards, query_params, standard_name_dropdown):
     try:
         platform_options = platform_standards[standard_name_dropdown.value]
         selected_ts_keys = mo.ui.multiselect(
             sorted(platform_options.keys()),
             label="Platforms",
             max_selections=10,
+            value=common.query_param_list_default(
+                query_params,
+                "platforms",
+                platform_options,
+                fallback=[],
+            ),
+            on_change=lambda value: query_params.set("platforms", ",".join(value)),
         )
     except KeyError:
         selected_ts_keys = None

--- a/common.py
+++ b/common.py
@@ -186,6 +186,20 @@ def query_param_int(query_params, key, *, fallback, minimum=0, maximum=None):
     return int(result)
 
 
+def query_param_list_default(query_params, key: str, options, *, fallback):
+    """Comma-separated query parameter values that are valid options, else ``fallback``.
+
+    Mirrors query_param_default for multi-value widgets like mo.ui.multiselect:
+    any stored entry no longer among options (e.g. left over from a different
+    platform's timeseries names) is dropped rather than passed through.
+    """
+    value = query_params.get(key)
+    if not value:
+        return fallback
+    selected = [item for item in value.split(",") if item in options]
+    return selected or fallback
+
+
 def erddap_client(ts: dict):
     """A configured erddapy client for a Buoy Barn timeseries."""
     import erddapy

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -138,6 +138,59 @@ def test_query_param_default_falls_back_when_unset():
     assert common.query_param_default(FakeQueryParams(), "year", ["2024"]) is None
 
 
+def test_query_param_list_default_accepts_comma_separated_values_that_are_options():
+    params = FakeQueryParams(ts="Air Temperature,Water Temperature")
+
+    assert common.query_param_list_default(
+        params,
+        "ts",
+        ["Air Temperature", "Water Temperature", "Wind Speed"],
+        fallback=[],
+    ) == ["Air Temperature", "Water Temperature"]
+
+
+def test_query_param_list_default_drops_entries_left_over_from_another_platform():
+    params = FakeQueryParams(ts="Air Temperature,Water Temperature @ 50.0m")
+
+    assert common.query_param_list_default(
+        params,
+        "ts",
+        ["Air Temperature"],
+        fallback=[],
+    ) == ["Air Temperature"]
+
+
+def test_query_param_list_default_falls_back_when_unset():
+    assert common.query_param_list_default(
+        FakeQueryParams(),
+        "ts",
+        ["Air Temperature"],
+        fallback=["fell"],
+    ) == ["fell"]
+
+
+def test_query_param_list_default_falls_back_when_empty_string():
+    params = FakeQueryParams(ts="")
+
+    assert common.query_param_list_default(
+        params,
+        "ts",
+        ["Air Temperature"],
+        fallback=["fell"],
+    ) == ["fell"]
+
+
+def test_query_param_list_default_falls_back_when_every_entry_is_invalid():
+    params = FakeQueryParams(ts="Water Temperature @ 50.0m")
+
+    assert common.query_param_list_default(
+        params,
+        "ts",
+        ["Air Temperature"],
+        fallback=["fell"],
+    ) == ["fell"]
+
+
 def test_query_param_int_accepts_a_valid_stored_value():
     params = FakeQueryParams(threshold_daily="5")
 


### PR DESCRIPTION
by_platform's platform/timeseries selectors and by_standard_name's platform
multiselect now sync to the URL via mo.query_params(), mirroring the pattern
already used by climatology.py and by_standard_name's data-type dropdown.

Adds `query_param_list_default()` in common.py for multi-value widgets.

Closes #163

Assisted-by: claude-code:claude-sonnet-5