### PR TITLE
Hide platforms with no readings from By Buoy and Climatology dropdowns

### DIFF
--- a/by_platform.py
+++ b/by_platform.py
@@ -40,7 +40,7 @@ def _():
 
 @app.cell
 def _(platform_json):
-    platforms = common.platforms_by_name(platform_json)
+    platforms = common.platforms_with_readings(common.platforms_by_name(platform_json))
     return (platforms,)
 
 

--- a/climatology.py
+++ b/climatology.py
@@ -36,7 +36,7 @@ def _():
 
 @app.cell
 def _(platform_json):
-    platforms = common.platforms_by_name(platform_json)
+    platforms = common.platforms_with_readings(common.platforms_by_name(platform_json))
     return (platforms,)
 
 

--- a/common.py
+++ b/common.py
@@ -131,6 +131,19 @@ def platforms_by_name(platform_json: dict) -> dict:
     return dict(sorted(platforms.items()))
 
 
+def platforms_with_readings(platforms: dict) -> dict:
+    """``platforms`` narrowed to those with at least one reading to plot.
+
+    A platform with an empty ``readings`` array is a dead end for any page
+    here that lets you pick a timeseries next -- there's nothing to select.
+    """
+    return {
+        name: feature
+        for name, feature in platforms.items()
+        if feature["properties"]["readings"]
+    }
+
+
 def name_for_ts(ts: dict) -> str:
     """Label for a timeseries: its long name, plus the depth when it has one."""
     name = ts["data_type"]["long_name"]

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -94,6 +94,47 @@ def test_platform_display_name_concatenates_id_and_station_name():
     assert common.platform_display_name(feature) == "A01 - Mass Bay"
 
 
+def test_platforms_with_readings_keeps_a_platform_that_has_readings():
+    platforms = {
+        "44005 - Western Maine Shelf": {
+            "id": "44005",
+            "properties": {"readings": [reading("Air Temperature")]},
+        },
+    }
+
+    result = common.platforms_with_readings(platforms)
+
+    assert list(result) == ["44005 - Western Maine Shelf"]
+
+
+def test_platforms_with_readings_drops_a_platform_with_no_readings():
+    platforms = {
+        "44007": {"id": "44007", "properties": {"readings": []}},
+    }
+
+    result = common.platforms_with_readings(platforms)
+
+    assert result == {}
+
+
+def test_platforms_with_readings_preserves_order_of_survivors():
+    platforms = {
+        "44005 - Western Maine Shelf": {
+            "id": "44005",
+            "properties": {"readings": [reading("Air Temperature")]},
+        },
+        "44007": {"id": "44007", "properties": {"readings": []}},
+        "A01 - Mass Bay": {
+            "id": "A01",
+            "properties": {"readings": [reading("Water Temperature", depth=1.0)]},
+        },
+    }
+
+    result = common.platforms_with_readings(platforms)
+
+    assert list(result) == ["44005 - Western Maine Shelf", "A01 - Mass Bay"]
+
+
 def test_platform_display_name_falls_back_to_id_only():
     feature = {"id": "44007", "properties": {"station_name": None}}
     assert common.platform_display_name(feature) == "44007"


### PR DESCRIPTION
Picking a platform with an empty readings list is a dead end on both
pages -- there is nothing to select next and nothing to plot. Adds an
opt-in common.platforms_with_readings() filter each page applies to its
own platform dict, rather than changing platforms_by_name() itself.

Fixes #138

Assisted-by: claude-code:claude-sonnet-5