### PR TITLE
Fit the stacked by-buoy chart to its container (#162)

### DIFF
--- a/by_platform.py
+++ b/by_platform.py
@@ -268,8 +268,35 @@ def _(filtered_df, platform_selector, unit_ts):
             )
         stack &= _row.properties(width="container")
 
+    # The rows' width="container" is only half of responsive sizing, and the
+    # autosize below is the other half. Vega-Lite derives an
+    # autosize: fit-x from width="container" for single and layered views, but
+    # never for a vconcat -- it warns "Width 'container' only works for single
+    # views and layered views" and compiles no autosize at all. Without it,
+    # width="container" sizes each row's *plotting area* to the full container
+    # width and the y-axis labels, legend and padding then push the canvas
+    # ~190px past it: the canvas overflows div.chart-wrapper (overflow-x:
+    # auto), which crops the logo and hides the colour legend entirely (#162).
+    #
+    # fit-x, not fit: Vega-Lite silently downgrades autosize fit to pad for
+    # concat views, which puts the overflow straight back.
+    #
+    # The width="container" here is *not* redundant with the rows', and not
+    # dead weight either, despite being schema-invalid on a VConcatChart
+    # ("VConcatChart has no parameter named 'width'") and surviving only
+    # because mo.ui.altair_chart serializes with to_dict(validate=False).
+    # marimo's frontend attaches its container ResizeObserver only when the
+    # *top-level* spec width is "container"; that observer is what dispatches
+    # the window:resize the compiled width signal listens for when the
+    # container changes width without the window doing so -- collapsing the
+    # sidebar being the case that happens. Drop it and the canvas stays frozen
+    # at its old width in a wider wrapper (measured: 752px canvas, 972px
+    # wrapper) until an actual window resize comes along.
     mo.ui.altair_chart(
-        stack.properties(width="container"),
+        stack.properties(
+            width="container",
+            autosize=alt.AutoSizeParams(type="fit-x", contains="padding"),
+        ),
         chart_selection=False,
         legend_selection=False,
     )

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -67,6 +67,55 @@ def assert_chart_rendered(page: Page, *, min_width: int = MIN_CHART_WIDTH) -> No
         f"chart width {box['width']} <= {min_width}; expected a full-width chart"
     )
 
+    _assert_chart_fits_wrapper(chart)
+
+
+def _assert_chart_fits_wrapper(chart: Locator) -> None:
+    """Assert the settled canvas is no wider than the wrapper that scrolls it.
+
+    "Fills its container" has to mean *fills*, not *overflows*. Vega-Lite only
+    compiles width="container" into an autosize: fit-x for single and layered
+    views, so a vconcat sized that way makes each row's plotting area the full
+    container width and lets the axes, legend and padding spill ~190px past it
+    -- cropping the chart's right edge (#162). Nothing else here catches that:
+    the min_width check above only gets wider when the canvas overflows.
+
+    Measure against div.chart-wrapper, the overflow-x: auto element vega-embed
+    wraps the canvas in, since that is what does the cropping. scrollWidth
+    exceeding clientWidth is the direct statement of "this wrapper is scrolling
+    because its content does not fit".
+    """
+    # The canvas lives in a shadow root, so document.querySelector() inside the
+    # page never finds it -- hand the element Playwright already pierced to
+    # evaluate() as an argument instead of re-querying from document.
+    measured = chart.evaluate(
+        """(canvas) => {
+            const wrapper = canvas.closest(".chart-wrapper");
+            if (!wrapper) return null;
+            return {
+                canvas: canvas.getBoundingClientRect().width,
+                clientWidth: wrapper.clientWidth,
+                scrollWidth: wrapper.scrollWidth,
+            };
+        }""",
+    )
+    assert measured is not None, (
+        "chart canvas has no .chart-wrapper ancestor; vega-embed's DOM shape "
+        "changed and this assertion needs updating"
+    )
+
+    # A pixel of slack: widths are fractional and clientWidth is rounded.
+    slack = 2
+    assert measured["canvas"] <= measured["clientWidth"] + slack, (
+        f"chart canvas is {measured['canvas']}px wide but its .chart-wrapper is "
+        f"only {measured['clientWidth']}px; the chart is overflowing and its "
+        f"right edge is cropped"
+    )
+    assert measured["scrollWidth"] <= measured["clientWidth"] + slack, (
+        f".chart-wrapper scrollWidth {measured['scrollWidth']}px exceeds its "
+        f"clientWidth {measured['clientWidth']}px; chart content overflows it"
+    )
+
 
 def assert_hover_tooltip_appears(page: Page) -> None:
     """Move the mouse over the settled chart and confirm a tooltip shows.


### PR DESCRIPTION
Vega-Lite only derives an autosize: fit-x from width="container" for
single and layered views, never for a vconcat. Without it the rows'
width="container" sized each plotting area to the full container width,
and the axes, legend and padding then pushed the canvas ~190px past it
-- overflowing div.chart-wrapper, which cropped the NERACOOS logo and
put the colour legend off-screen entirely.

Ask for autosize fit-x by name on the vconcat. The top-level
width="container" stays even though it is schema-invalid there: it is
what makes marimo attach the container ResizeObserver, without which the
canvas stays frozen at its old width when the sidebar is collapsed.

assert_chart_rendered now also asserts the canvas is no wider than the
.chart-wrapper that scrolls it, so all three chart pages guard against
the overflow coming back.

Fixes #162

Assisted-by: claude-code:claude-opus-5