### PR TITLE
Units toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ app framework to allow rapid iteration and then a Streamlit-like experience.
 - `pixi run edit` - Opens Marimo notebooks in the browser for editing.
 - `pixi run app` - Runs the app in the browser in a non-editable mode.
 
+## Display units
+
+By Buoy, By Data Type and Climatology show English units by default, with a
+Metric toggle at the foot of the sidebar. The conversion table lives in
+`units.py`, keyed on CF standard name and driven by the unit string Buoy Barn
+reports for each reading. A standard name it does not know about is passed
+through in whatever unit it arrived in. Barometric pressure is mb in both
+systems.
+
+The choice is stored in the `?units=` query-param, so a shared link keeps the
+units its sender saw, and is remembered in `localStorage` between pages and
+sessions (`units.head_script()`, injected into every page's `<head>` by
+`app.py`). An explicit `?units=` in the URL wins over the remembered one.
+
 ## End-to-end tests
 
 - `pixi run -e test e2e-install` - Downloads the Chromium browser for Playwright

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import marimo
 from fastapi import FastAPI
 
 import monitoring
+import units
 
 # Before create_asgi_app()/FastAPI(): Sentry instruments Starlette by patching
 # middleware construction, so apps built before init are not traced. Run-mode
@@ -11,9 +12,15 @@ import monitoring
 monitoring.init_sentry()
 
 server = (
-    # Injected before </head> of every notebook page; None unless SENTRY_DSN is
-    # set, so nothing third-party loads outside a configured deployment.
-    marimo.create_asgi_app(html_head=monitoring.html_head())
+    # Injected before </head> of every notebook page. The Sentry half is None
+    # unless SENTRY_DSN is set, so nothing third-party loads outside a
+    # configured deployment; the units half is always present and reaches for
+    # nothing but localStorage.
+    marimo.create_asgi_app(
+        html_head="".join(
+            part for part in (monitoring.html_head(), units.head_script()) if part
+        ),
+    )
     .with_app(path="/", root="./root.py")
     .with_app(path="/by_platform", root="./by_platform.py")
     .with_app(path="/by_standard_name", root="./by_standard_name.py")

--- a/by_platform.py
+++ b/by_platform.py
@@ -13,12 +13,15 @@ with app.setup:
 
     import common
     import monitoring
+    import units
 
 
 @app.cell
-def _():
+def _(query_params):
     common.set_defaults(page="by_platform")
-    common.sidebar_menu()
+    units_radio = common.units_radio(query_params)
+    common.sidebar_menu(units_radio)
+    return (units_radio,)
 
 
 @app.cell
@@ -98,7 +101,7 @@ def _(platform_selector, time_series_selector):
 
 
 @app.cell
-def _(platform_selector, time_series_selector):
+def _(platform_selector, time_series_selector, units_radio):
     loaded_ts = {}
     unit_ts = {}
 
@@ -110,14 +113,28 @@ def _(platform_selector, time_series_selector):
                 sorted(common.name_for_ts(_ts) for _ts in time_series_selector.value),
             ),
         )
+    monitoring.tag_context(units=units_radio.value)
 
     with mo.status.spinner(title="Loading data from ERDDAP"):
         for _ts in time_series_selector.value:
             _col_name = common.name_for_ts(_ts)
-            _unit = _ts["data_type"]["units"]
+            _source = _ts["data_type"]["units"]
+            _target = units.target_unit(
+                _ts["data_type"]["standard_name"],
+                _source,
+                units_radio.value,
+            )
+            # Keyed by the display label, not the source unit, because that key
+            # is what the subplots are grouped by: a buoy reporting
+            # barometric_pressure in millibars and air_pressure in mbar used to
+            # get two pressure rows, and now gets one.
+            _unit = units.label(_target)
             _key = (_col_name, _unit)
             try:
                 _df = common.load_ts(_ts, _col_name)
+                # load_ts hands back a fresh frame every call, so converting in
+                # place cannot poison the cache behind it.
+                _df[_col_name] = units.convert(_df[_col_name], _source, _target)
                 loaded_ts[_key] = _df
                 unit_ts.setdefault(_unit, []).append(_col_name)
             except common.ErddapLoadError as error:

--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -13,6 +13,7 @@ with app.setup:
 
     import common
     import monitoring
+    import units
 
 
 @app.cell
@@ -27,9 +28,11 @@ def _():
 
 
 @app.cell
-def _():
+def _(query_params):
     common.set_defaults(page="by_standard_name")
-    common.sidebar_menu()
+    units_radio = common.units_radio(query_params)
+    common.sidebar_menu(units_radio)
+    return (units_radio,)
 
 
 @app.cell
@@ -118,9 +121,9 @@ def _(selected_ts_keys, standard_name_dropdown):
 
 
 @app.cell
-def _(standard_name_dropdown, standards):
+def _(standard_name_dropdown, standards, units_radio):
     try:
-        unit = standards[standard_name_dropdown.value]["units"]
+        _data_type = standards[standard_name_dropdown.value]
     except KeyError:
         mo.stop(
             True,
@@ -130,7 +133,22 @@ def _(standard_name_dropdown, standards):
                 kind="attention",
             ),
         )
-    return (unit,)
+
+    # Every platform on this page reports the same standard name, and no
+    # standard name Buoy Barn serves is spelled with more than one unit
+    # string, so one source unit covers the whole comparison.
+    source_unit = _data_type["units"]
+    target_unit = units.target_unit(
+        standard_name_dropdown.value,
+        source_unit,
+        units_radio.value,
+    )
+    # ``unit`` names the melted frame's value column, which is also the chart's
+    # y encoding and the tooltip's field, so the display label reaches all
+    # three by being this one string.
+    unit = units.label(target_unit)
+    monitoring.tag_context(units=units_radio.value)
+    return source_unit, target_unit, unit
 
 
 @app.cell
@@ -145,7 +163,14 @@ def _(selected_ts_keys):
 
 
 @app.cell
-def _(platform_options, selected_ts_keys, standard_name_dropdown, unit):
+def _(
+    platform_options,
+    selected_ts_keys,
+    source_unit,
+    standard_name_dropdown,
+    target_unit,
+    unit,
+):
     _wide_dfs = []
 
     if standard_name_dropdown.value:
@@ -176,6 +201,10 @@ def _(platform_options, selected_ts_keys, standard_name_dropdown, unit):
                 _wide_dfs.append(_df)
 
             wide_df = pd.concat(_wide_dfs, axis=1)
+            # Converted once, here, rather than per platform: every column is
+            # the same standard name in the same source unit, and both
+            # accordion downloads below hang off this frame.
+            wide_df = units.convert(wide_df, source_unit, target_unit)
             wide_melted = pd.melt(wide_df.reset_index(), id_vars="time (UTC)")
             wide_melted = wide_melted.rename(
                 columns={"variable": "Timeseries", "value": unit},

--- a/climatology.py
+++ b/climatology.py
@@ -10,12 +10,15 @@ with app.setup:
     import climatology_core as core
     import common
     import monitoring
+    import units
 
 
 @app.cell
-def _():
+def _(query_params):
     common.set_defaults(page="climatology")
-    common.sidebar_menu()
+    units_radio = common.units_radio(query_params)
+    common.sidebar_menu(units_radio)
+    return (units_radio,)
 
 
 @app.cell
@@ -116,6 +119,24 @@ def _(platform, timeseries_dropdown):
         )
     monitoring.tag_context(platform=platform["id"], dataset=ts["app_name"])
     return (ts,)
+
+
+@app.cell
+def _(ts, units_radio):
+    # The mean, min and max of an affine conversion are the conversion of the
+    # mean, min and max, so the display frames further down are converted
+    # rather than the observations: flipping the toggle costs no ERDDAP
+    # refetch and no recomputed climatology. The threshold histogram counts
+    # observations, so it is untouched either way.
+    source_unit = ts["data_type"]["units"]
+    display_unit = units.target_unit(
+        ts["data_type"]["standard_name"],
+        source_unit,
+        units_radio.value,
+    )
+    unit_label = units.label(display_unit)
+    monitoring.tag_context(units=units_radio.value)
+    return display_unit, source_unit, unit_label
 
 
 @app.cell
@@ -304,9 +325,12 @@ def _(end_year_dropdown, means, start_year_dropdown, threshold):
 @app.cell
 def _(
     average_period_dropdown,
+    display_unit,
     end_year_dropdown,
     means_filtered,
+    source_unit,
     start_year_dropdown,
+    unit_label,
     year_dropdown,
 ):
     _period = average_period_dropdown.value
@@ -316,7 +340,20 @@ def _(
     with monitoring.operation("climatology.climatology", op="compute"):
         clim_df = core.climatology(means_filtered, _period, year_dropdown.value)
 
-    _range = f"({start_year_dropdown.value} - {end_year_dropdown.value})"
+    # Converted before the rounding below, not after, so the two decimals the
+    # observations justify are two decimals of the displayed unit.
+    _value_columns = ["mean", "min", "max"]
+    clim_df[_value_columns] = units.convert(
+        clim_df[_value_columns],
+        source_unit,
+        display_unit,
+    )
+
+    # The unit rides along in the column names rather than only on the axis:
+    # the tooltip, the selection table, the data table and its CSV download
+    # all address these fields by name, so naming them is all it takes for
+    # every one of them to follow the toggle.
+    _range = f"({start_year_dropdown.value} - {end_year_dropdown.value}) ({unit_label})"
     mean_range_name = f"Mean {_range}"
     min_range_name = f"Min {_range}"
     max_range_name = f"Max {_range}"
@@ -425,23 +462,40 @@ def _(clim_tooltip, df_plot, mean_range_name, time_axis, time_col):
 
 
 @app.cell
-def _(average_period_dropdown, column, df_no_index, year_dropdown):
-    # Rounded here so the hover, the selection table and the data table all
-    # show the two decimals the observations justify.
-    df_year = core.year_series(
+def _(
+    average_period_dropdown,
+    column,
+    df_no_index,
+    display_unit,
+    source_unit,
+    year_dropdown,
+):
+    _df_year = core.year_series(
         df_no_index,
         column,
         average_period_dropdown.value,
         year_dropdown.value,
-    ).round({"mean": 2})
+    )
+    _df_year["mean"] = units.convert(_df_year["mean"], source_unit, display_unit)
+
+    # Rounded here so the hover, the selection table and the data table all
+    # show the two decimals the observations justify.
+    df_year = _df_year.round({"mean": 2})
     return (df_year,)
 
 
 @app.cell
-def _(average_period_dropdown, clim_df, df_year, time_col, year_dropdown):
+def _(
+    average_period_dropdown,
+    clim_df,
+    df_year,
+    time_col,
+    unit_label,
+    year_dropdown,
+):
     year_column = (
         f"{'Daily' if average_period_dropdown.value == core.DAILY else 'Monthly'} mean"
-        f" for {year_dropdown.value}"
+        f" for {year_dropdown.value} ({unit_label})"
     )
 
     # Every layer draws from one frame, so a single hover reports the
@@ -464,8 +518,8 @@ def _(average_period_dropdown, clim_df, df_year, time_col, year_dropdown):
 
 
 @app.cell
-def _(clim_tooltip, df_plot, time_axis, time_col, ts, year_column):
-    _y_title = f"{ts['data_type']['long_name']} ({ts['data_type']['units']})"
+def _(clim_tooltip, df_plot, time_axis, time_col, ts, unit_label, year_column):
+    _y_title = f"{ts['data_type']['long_name']} ({unit_label})"
 
     # Points and a connecting line. year_series lays the means over every period
     # of the year, so a gap in the data is a null and Vega breaks the line there
@@ -530,11 +584,18 @@ def _(end_year_dropdown, platform, start_year_dropdown, ts):
 
 
 @app.cell
-def _(average_period_dropdown, clim_df, df_year, time_col, year_dropdown):
+def _(
+    average_period_dropdown,
+    clim_df,
+    df_year,
+    time_col,
+    unit_label,
+    year_dropdown,
+):
     _period = average_period_dropdown.value
     _year_column = (
         f"{'Daily' if _period == core.DAILY else 'Monthly'} means"
-        f" for {year_dropdown.value}"
+        f" for {year_dropdown.value} ({unit_label})"
     )
 
     df_combined = clim_df.merge(

--- a/common.py
+++ b/common.py
@@ -8,6 +8,11 @@ import marimo as mo
 import pandas as pd
 
 import monitoring
+import units
+
+# The unit systems the sidebar toggle offers, English first so it is the
+# default -- see units_radio() below.
+UNIT_SYSTEMS = (units.ENGLISH, units.METRIC)
 
 # Maximum number of rows that Altair will render
 MAX_ROWS = 10_000
@@ -474,8 +479,40 @@ def linked_hover(
     return alt.layer(line, points, rule, hit), hover
 
 
-def sidebar_menu():
-    """Build a sidebar menu"""
+def units_radio(query_params):
+    """The sidebar unit toggle, round-tripped through ``?units=``.
+
+    Build this in the same cell that renders the sidebar. marimo re-runs the
+    *descendants* of the cell that defines a UI element, not the defining cell
+    itself, so keeping the two together is what stops every toggle from
+    re-rendering the sidebar the radio is sitting in.
+
+    Written on change only, like the dropdowns: seeding the parameter eagerly
+    would put ``?units=`` on the URL of a page nobody has touched the toggle
+    on, which the end-to-end suite asserts against.
+    """
+    return mo.ui.radio(
+        options=list(UNIT_SYSTEMS),
+        label="Units",
+        inline=True,
+        value=query_param_default(
+            query_params,
+            "units",
+            UNIT_SYSTEMS,
+            fallback=units.ENGLISH,
+        ),
+        # Guarded like the dropdowns: clearing the selection hands the
+        # callback None, which is not a unit system.
+        on_change=lambda value: query_params.set("units", value) if value else None,
+    )
+
+
+def sidebar_menu(unit_toggle=None):
+    """Build a sidebar menu, with the unit toggle at its foot if given.
+
+    ``unit_toggle`` is the ``units_radio()`` of a page that has one; ``root``
+    and the datum calculator pass nothing and get the menu alone.
+    """
     return mo.sidebar(
         [
             mo.Html("""
@@ -510,6 +547,7 @@ def sidebar_menu():
                 },
                 orientation="vertical",
             ),
+            *([mo.md("---"), unit_toggle] if unit_toggle is not None else []),
         ],
     )
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -199,6 +199,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.141.1-h76d476e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.32-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.141.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -228,6 +230,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
@@ -287,6 +291,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.141.1-h76d476e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.32-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.141.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -316,6 +322,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
@@ -690,6 +698,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.141.1-h76d476e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.32-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.141.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -720,6 +730,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/playwright-python-1.62.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -789,6 +801,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.141.1-h76d476e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.32-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.141.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -819,6 +833,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/playwright-python-1.62.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -4142,6 +4158,33 @@ packages:
   run_exports: {}
   size: 105158
   timestamp: 1785373461610
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+  sha256: acdb7b73d84268773fcc8192965994554411edc488ec3447925a62154e9d3baa
+  md5: f1e618f2f783427019071b14a111b30d
+  depends:
+  - python >=3.9
+  - typing-extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/flexcache?source=hash-mapping
+  run_exports: {}
+  size: 16674
+  timestamp: 1733663669958
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
+  sha256: 9bdad0cd9fb6d67e48798c03930d634ea2d33a894d30439d3d7bdffd3c21af7b
+  md5: 6dc4e43174cd552452fdb8c423e90e69
+  depends:
+  - python >=3.9
+  - typing-extensions
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/flexparser?source=hash-mapping
+  run_exports: {}
+  size: 28686
+  timestamp: 1733663636245
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -4551,6 +4594,38 @@ packages:
   run_exports: {}
   size: 82472
   timestamp: 1777722955579
+- conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+  sha256: f58a03dd2908c15dc65fab7e03a0212c69043466f7f85a4e345470492841782f
+  md5: 293c4719f6d62778ffecd18e024a8fcd
+  depends:
+  - python >=3.11
+  - platformdirs >=2.1.0
+  - flexcache >=0.3
+  - flexparser >=0.4
+  - typing_extensions >=4.0.0
+  - python
+  constrains:
+  - numpy >=1.23
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pint?source=hash-mapping
+  run_exports: {}
+  size: 245230
+  timestamp: 1773969991837
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
+  sha256: a4b8c7d3b3703d10f93187986d59aec09b22033978945845899beb7f849a7be6
+  md5: 1fadaa6dd1d03d062075f84157ac2cc7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=hash-mapping
+  run_exports: {}
+  size: 26632
+  timestamp: 1784661349391
 - conda: https://conda.anaconda.org/conda-forge/noarch/playwright-python-1.62.0-pyhcf101f3_0.conda
   sha256: 1fcfa369cd42e62bd5e52c5c434a7026653d98f12bb1df7fa87295818acad57b
   md5: 7eaf6fc86d97097f0c0b59f65602947a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ requests = ">=2.32.5,<3"
 pydantic = ">=2.12"
 httpx2 = ">=2.5.0,<3"
 sentry-sdk = ">=2.66,<3"
+pint = ">=0.25.3,<0.26"
 
 [tool.pixi.environments]
 test = { features = [ "test" ], solve-group = "default" }

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -118,11 +118,20 @@ def _assert_chart_fits_wrapper(chart: Locator) -> None:
 
 
 def assert_hover_tooltip_appears(page: Page) -> None:
-    """Move the mouse over the settled chart and confirm a tooltip shows.
+    """Move the mouse over the settled chart and confirm a tooltip shows."""
+    hover_for_tooltip(page)
+
+
+def hover_for_tooltip(page: Page) -> Locator:
+    """Move the mouse over the settled chart until a tooltip shows, and return it.
 
     by_platform.py stacks one subplot per unit in a single canvas, so the
     exact vertical center can land in the gap between rows rather than on
     either plot -- try a few y positions rather than only the center.
+
+    Returned rather than merely asserted so a caller can read what the tooltip
+    says: the chart itself is a canvas, so its axis titles are invisible to the
+    DOM and the tooltip is the only place a unit is assertable.
     """
     chart = wait_for_chart_settled(page)
     box = chart.bounding_box()
@@ -138,9 +147,10 @@ def assert_hover_tooltip_appears(page: Page) -> None:
         )
         page.wait_for_timeout(300)
         if tooltip.is_visible():
-            return
+            return tooltip
 
     expect(tooltip).to_be_visible()
+    return tooltip
 
 
 def download_chart_png(page: Page) -> Download:

--- a/tests/e2e/test_by_platform.py
+++ b/tests/e2e/test_by_platform.py
@@ -1,7 +1,10 @@
+import re
+
 from helpers import (
     assert_chart_rendered,
     assert_hover_tooltip_appears,
     download_chart_png,
+    hover_for_tooltip,
 )
 from playwright.sync_api import Page, expect
 
@@ -28,3 +31,22 @@ def test_western_maine_shelf(page: Page) -> None:
     with page.expect_download() as csv_download_info:
         page.get_by_role("menuitem", name="CSV").first.click()
     assert csv_download_info.value.suggested_filename.endswith(".csv")
+
+
+def test_unit_toggle_switches_the_displayed_unit(page: Page) -> None:
+    """English by default. Barometric pressure is mb either way, so the pair
+    also shows that only the family that has an English unit moves."""
+    page.goto(
+        "/by_platform/?platform=B01&ts=Air+Temperature%2CBarometric+Pressure",
+    )
+
+    tooltip = hover_for_tooltip(page)
+    expect(tooltip).to_contain_text("(°F)")
+    expect(tooltip).to_contain_text("(mb)")
+
+    page.get_by_role("radio", name="Metric").click()
+    expect(page).to_have_url(re.compile(r"units=Metric"))
+
+    tooltip = hover_for_tooltip(page)
+    expect(tooltip).to_contain_text("(°C)")
+    expect(tooltip).to_contain_text("(mb)")

--- a/tests/e2e/test_by_standard_name.py
+++ b/tests/e2e/test_by_standard_name.py
@@ -1,7 +1,10 @@
+import re
+
 from helpers import (
     assert_chart_rendered,
     assert_hover_tooltip_appears,
     download_chart_png,
+    hover_for_tooltip,
 )
 from playwright.sync_api import Page, expect
 
@@ -35,3 +38,21 @@ def test_air_temp(page: Page) -> None:
     with page.expect_download() as csv_download_info:
         page.get_by_role("menuitem", name="CSV").first.click()
     assert csv_download_info.value.suggested_filename.endswith(".csv")
+
+
+def test_unit_toggle_switches_the_displayed_unit(page: Page) -> None:
+    """The unit names the melted frame's value column, so it reaches the chart
+    and the tooltip through the one string -- and the tooltip is the only place
+    the DOM can see it, the chart being a canvas."""
+    page.goto("/by_standard_name/?standard_name=air_temperature")
+
+    page.get_by_text("Select...").click()
+    page.get_by_role("option", name="44007").click()
+    page.get_by_role("listbox", name="Suggestions").press("Escape")
+
+    expect(hover_for_tooltip(page)).to_contain_text("(°F)")
+
+    page.get_by_role("radio", name="Metric").click()
+    expect(page).to_have_url(re.compile(r"units=Metric"))
+
+    expect(hover_for_tooltip(page)).to_contain_text("(°C)")

--- a/tests/e2e/test_climatology.py
+++ b/tests/e2e/test_climatology.py
@@ -2,8 +2,14 @@
 End-to-end tests for the Climatology page of the application.
 """
 
+import re
+
 from helpers import assert_chart_rendered, download_chart_png
 from playwright.sync_api import Page, expect
+
+# The data table only appears once the climatology has been computed from a
+# full ERDDAP load, which is slower than Playwright's default assertion wait.
+RENDER_TIMEOUT = 60000
 
 
 def test_western_maine_shelf_air(page: Page) -> None:
@@ -19,6 +25,29 @@ def test_western_maine_shelf_air(page: Page) -> None:
     assert_chart_rendered(page)
 
     assert download_chart_png(page).suggested_filename.endswith(".png")
+
+
+def test_unit_toggle_switches_the_displayed_unit(page: Page) -> None:
+    """English by default, and the toggle reaches the data table as well as the
+    chart -- the chart is a canvas, so its axis is not assertable from the DOM,
+    but the table's column headers carry the same unit the axis does."""
+    page.goto("/climatology/?platform=B01+-+Western+Maine+Shelf&ts=Air+Temperature")
+    page.get_by_role("button", name="Show data").click()
+
+    expect(
+        page.get_by_role("columnheader").filter(has_text="(°F)").first,
+    ).to_be_visible(
+        timeout=RENDER_TIMEOUT,
+    )
+
+    page.get_by_role("radio", name="Metric").click()
+
+    expect(page).to_have_url(re.compile(r"units=Metric"))
+    expect(
+        page.get_by_role("columnheader").filter(has_text="(°C)").first,
+    ).to_be_visible(
+        timeout=RENDER_TIMEOUT,
+    )
 
 
 def test_monthly_averaging_period(page: Page) -> None:

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -10,6 +10,7 @@ import pytest
 import sentry_sdk
 
 import common
+import units
 
 TIME_INDEX = "time (UTC)"
 
@@ -177,6 +178,26 @@ def test_query_param_default_rejects_a_value_left_over_from_another_platform():
 
 def test_query_param_default_falls_back_when_unset():
     assert common.query_param_default(FakeQueryParams(), "year", ["2024"]) is None
+
+
+def test_units_radio_defaults_to_english():
+    assert common.units_radio(FakeQueryParams()).value == units.ENGLISH
+
+
+def test_units_radio_restores_the_query_parameter():
+    assert common.units_radio(FakeQueryParams(units="Metric")).value == units.METRIC
+
+
+def test_units_radio_ignores_a_unit_system_it_does_not_offer():
+    params = FakeQueryParams(units="Imperial")
+
+    assert common.units_radio(params).value == units.ENGLISH
+
+
+def test_sidebar_menu_renders_with_and_without_the_toggle():
+    """Root and the datum calculator call it bare; the three viz pages don't."""
+    assert common.sidebar_menu() is not None
+    assert common.sidebar_menu(common.units_radio(FakeQueryParams())) is not None
 
 
 def test_query_param_list_default_accepts_comma_separated_values_that_are_options():

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,0 +1,283 @@
+"""Unit tests for display unit conversion."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import units
+
+
+def rounded(values: pd.Series) -> list[float]:
+    """Values rounded to 2dp for comparison against the verified numbers."""
+    return np.round(values.to_numpy(), 2).tolist()
+
+
+# Real (standard_name, source) pairs Buoy Barn returns today, with the
+# verified English and Metric results (rounded to 2dp). Visibility is the one
+# family where Metric is not a no-op: the source is metres but the Metric
+# target is km.
+BUOY_BARN_CASES = [
+    (
+        "air_temperature",
+        "celsius",
+        [0.0, 10.0, 21.5],
+        [32.0, 50.0, 70.7],
+        "degree_Fahrenheit",
+        "°F",
+        [0.0, 10.0, 21.5],
+        "degree_Celsius",
+        "°C",
+    ),
+    (
+        # Exercises the degree_C alias -- ERDDAP's own spelling.
+        "sea_surface_temperature",
+        "degree_C",
+        [0.0, 10.0, 21.5],
+        [32.0, 50.0, 70.7],
+        "degree_Fahrenheit",
+        "°F",
+        [0.0, 10.0, 21.5],
+        "degree_Celsius",
+        "°C",
+    ),
+    (
+        "wind_speed",
+        "m/s",
+        [1.0, 10.0],
+        [1.94, 19.44],
+        "knot",
+        "kn",
+        [1.0, 10.0],
+        "m/s",
+        "m/s",
+    ),
+    (
+        "significant_wave_height",
+        "m",
+        [1.0, 2.5],
+        [3.28, 8.2],
+        "foot",
+        "ft",
+        [1.0, 2.5],
+        "m",
+        "m",
+    ),
+    (
+        "visibility_in_air",
+        "meters",
+        [1852.0, 10000.0],
+        [1.0, 5.4],
+        "nautical_mile",
+        "nmi",
+        [1.85, 10.0],
+        "km",
+        "km",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    (
+        "standard_name",
+        "source",
+        "raw",
+        "english",
+        "english_unit",
+        "english_label",
+        "metric",
+        "metric_unit",
+        "metric_label",
+    ),
+    BUOY_BARN_CASES,
+    ids=[case[0] for case in BUOY_BARN_CASES],
+)
+def test_buoy_barn_inventory_converts_for_both_systems(
+    standard_name,
+    source,
+    raw,
+    english,
+    english_unit,
+    english_label,
+    metric,
+    metric_unit,
+    metric_label,
+):
+    values = pd.Series(raw, name="value")
+
+    target = units.target_unit(standard_name, source, units.ENGLISH)
+    assert target == english_unit
+    assert rounded(units.convert(values, source, target)) == english
+    assert units.label(target) == english_label
+
+    target = units.target_unit(standard_name, source, units.METRIC)
+    assert target == metric_unit
+    assert rounded(units.convert(values, source, target)) == metric
+    assert units.label(target) == metric_label
+
+
+# barometric_pressure/millibars, air_pressure/mbar and air_pressure_at_sea_level/hPa
+# are the same physical unit under three different spellings -- issue #144
+# put mb (not psi) in TARGETS for both systems, since that is what mariners
+# read off a barometer face.
+PRESSURE_CASES = [
+    ("barometric_pressure", "millibars"),
+    ("air_pressure", "mbar"),
+    ("air_pressure_at_sea_level", "hPa"),
+]
+
+
+@pytest.mark.parametrize(("standard_name", "source"), PRESSURE_CASES)
+@pytest.mark.parametrize("system", [units.ENGLISH, units.METRIC])
+def test_pressure_family_labels_as_mb_in_both_systems(standard_name, source, system):
+    values = pd.Series([1013.0, 1020.5])
+
+    target = units.target_unit(standard_name, source, system)
+    converted = units.convert(values, source, target)
+
+    assert units.label(target) == "mb"
+    assert rounded(converted) == [1013.0, 1020.5]
+
+
+# Standard names Buoy Barn reports that are absent from TARGETS, with the real
+# unit strings it uses for them.
+PASSTHROUGH_CASES = [
+    ("sea_water_salinity", "psu"),
+    ("turbidity", "ntu"),
+    ("sea_water_density", "kg/m^3"),
+    ("wind_from_direction", "degrees"),
+    ("sea_water_pressure", "decibars"),
+    ("sea_water_pH_reported_on_total_scale", "1"),
+]
+
+
+@pytest.mark.parametrize(("standard_name", "source"), PASSTHROUGH_CASES)
+@pytest.mark.parametrize("system", [units.ENGLISH, units.METRIC])
+def test_standard_names_outside_targets_pass_through_unchanged(
+    standard_name,
+    source,
+    system,
+):
+    values = pd.Series([1.0, 2.0, 3.0])
+
+    target = units.target_unit(standard_name, source, system)
+
+    assert target == source
+    assert units.convert(values, source, target).tolist() == values.tolist()
+
+
+def test_unparsable_source_passes_through_target_unit():
+    assert units.target_unit("air_temperature", "bogus_unit", units.ENGLISH) == (
+        "bogus_unit"
+    )
+
+
+def test_convert_leaves_values_alone_for_an_unparsable_source():
+    """convert() is expected to see this directly: target_unit() already
+    returns the source unchanged when it can't be parsed, but convert() must
+    not raise either, in case a caller reaches it with the mismatch still in
+    place."""
+    values = pd.Series([1.0, 2.0])
+
+    result = units.convert(values, "bogus_unit", "degree_Fahrenheit")
+
+    assert result.tolist() == [1.0, 2.0]
+
+
+def test_dimensionality_mismatch_passes_through_target_unit():
+    """air_temperature in metres makes no physical sense -- Buoy Barn and our
+    table disagree, which is a bug, but not one that should raise."""
+    target = units.target_unit("air_temperature", "m", units.ENGLISH)
+
+    assert target == "m"
+
+
+def test_dimensionality_mismatch_reports_to_monitoring(monkeypatch):
+    reported = {}
+
+    def fake_report(error, *, where, level, **tags):
+        reported["error"] = error
+        reported["where"] = where
+        reported["level"] = level
+        reported["tags"] = tags
+
+    monkeypatch.setattr(units.monitoring, "report", fake_report)
+
+    units.target_unit("air_temperature", "m", units.ENGLISH)
+
+    assert reported["where"] == "units.target_unit"
+    assert reported["level"] == "warning"
+    assert reported["tags"] == {
+        "standard_name": "air_temperature",
+        "source": "m",
+        "target": "degree_Fahrenheit",
+    }
+
+
+def test_resolved_dimensionality_mismatch_is_then_a_no_op_conversion():
+    """Once target_unit() has fallen back to the source, convert() sees
+    source == target and leaves the values alone rather than raising."""
+    values = pd.Series([1.0, 2.0])
+    target = units.target_unit("air_temperature", "m", units.ENGLISH)
+
+    result = units.convert(values, "m", target)
+
+    assert result.tolist() == [1.0, 2.0]
+
+
+def test_nan_survives_a_conversion():
+    values = pd.Series([0.0, np.nan, 21.5])
+
+    result = units.convert(values, "celsius", "degree_Fahrenheit")
+
+    assert result.iloc[0] == pytest.approx(32.0)
+    assert pd.isna(result.iloc[1])
+    assert result.iloc[2] == pytest.approx(70.7)
+
+
+def test_dataframe_converts_like_a_series_keeping_columns_and_index():
+    df = pd.DataFrame(
+        {"a": [0.0, 10.0], "b": [21.5, np.nan]},
+        index=["first", "second"],
+    )
+
+    result = units.convert(df, "celsius", "degree_Fahrenheit")
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["a", "b"]
+    assert list(result.index) == ["first", "second"]
+    assert rounded(result["a"]) == [32.0, 50.0]
+    assert result["b"].iloc[0] == pytest.approx(70.7)
+    assert pd.isna(result["b"].iloc[1])
+
+
+LABEL_CASES = [
+    ("degree_Celsius", "°C"),
+    ("degree_Fahrenheit", "°F"),
+    ("knot", "kn"),
+    ("foot", "ft"),
+    ("nautical_mile", "nmi"),
+    ("m/s", "m/s"),
+    ("m", "m"),
+    ("km", "km"),
+    ("celsius", "°C"),
+    ("ntu", "ntu"),
+    # The mb override, both spellings that TARGETS' pressure family can
+    # produce as a target string.
+    ("mbar", "mb"),
+    ("millibars", "mb"),
+    # Numerically identical to a millibar, but pint gives it a distinct
+    # symbol ("hPa"), so the override on the formatted result doesn't fire
+    # here directly -- it only ever sees "mbar", once target_unit() has
+    # already collapsed the pressure family onto that string.
+    ("hPa", "hPa"),
+    # Unparsable -- falls back to the raw string rather than raising.
+    ("bogus_unit", "bogus_unit"),
+    # pint formats the dimensionless unit as an empty string, which would
+    # otherwise render an axis as "Something ()".
+    ("1", "1"),
+]
+
+
+@pytest.mark.parametrize(("unit", "expected"), LABEL_CASES)
+def test_label(unit, expected):
+    assert units.label(unit) == expected

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -281,3 +281,29 @@ LABEL_CASES = [
 @pytest.mark.parametrize(("unit", "expected"), LABEL_CASES)
 def test_label(unit, expected):
     assert units.label(unit) == expected
+
+
+def test_head_script_is_a_self_contained_script_tag():
+    script = units.head_script()
+
+    assert script.startswith("<script>")
+    assert script.rstrip().endswith("</script>")
+    # Nothing third-party: the whole point of localStorage over a cookie is
+    # that the preference never leaves the browser.
+    assert "http://" not in script
+    assert "https://" not in script
+
+
+@pytest.mark.parametrize("system", [units.ENGLISH, units.METRIC])
+def test_head_script_allows_both_unit_systems(system):
+    assert f'"{system}"' in units.head_script()
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/by_platform", "/by_standard_name", "/climatology"],
+)
+def test_head_script_seeds_the_pages_that_have_a_toggle(path):
+    """Root and the datum calculator have no toggle, so no ?units= is seeded
+    onto their URLs."""
+    assert f'"{path}"' in units.head_script()

--- a/units.py
+++ b/units.py
@@ -13,6 +13,9 @@ so a newly flagged variable is already handled rather than silently falling
 back to passthrough the day it first appears.
 """
 
+import json
+from string import Template
+
 import pint
 
 import monitoring
@@ -81,6 +84,95 @@ TARGETS: dict[str, tuple[str, str]] = {
 # pressure family's target is literally the string "mbar" in TARGETS above,
 # regardless of which of the two the source happened to be.
 _LABEL_OVERRIDES = {"mbar": "mb"}
+
+
+# Pages that carry the sidebar toggle. The <head> snippet below is injected
+# into every notebook, root and the datum calculator included, and neither of
+# those has a unit preference to restore -- seeding one onto their URL would
+# just be a meaningless query string the user is left looking at.
+_TOGGLE_PATHS = ("/by_platform", "/by_standard_name", "/climatology")
+
+# Runs before marimo's own (deferred, module) bundle, so the URL is already
+# seeded by the time marimo reads its query parameters.
+#
+# ?units= stays the single source of truth: an explicit one in the URL always
+# wins over the stored preference, so a shared link keeps meaning what its
+# sender saw. localStorage rather than a cookie -- this is a first-party
+# display preference and the server has no use for it.
+_HEAD_SCRIPT = Template("""<script>
+(function () {
+  var KEY = "neracoos-units";
+  var PARAM = "units";
+  var ALLOWED = $systems;
+  var PATHS = $paths;
+
+  function stored() {
+    try {
+      var value = window.localStorage.getItem(KEY);
+      return ALLOWED.indexOf(value) === -1 ? null : value;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function persist() {
+    var value = new URLSearchParams(window.location.search).get(PARAM);
+    if (ALLOWED.indexOf(value) === -1) return;
+    try {
+      window.localStorage.setItem(KEY, value);
+    } catch (error) {
+      /* Private browsing refuses writes; the toggle still works per-tab. */
+    }
+  }
+
+  function onToggledPage() {
+    return PATHS.some(function (path) {
+      return window.location.pathname.indexOf(path) === 0;
+    });
+  }
+
+  var params = new URLSearchParams(window.location.search);
+  if (onToggledPage() && !params.has(PARAM)) {
+    var value = stored();
+    if (value) {
+      params.set(PARAM, value);
+      history.replaceState(
+        history.state,
+        "",
+        window.location.pathname + "?" + params.toString() + window.location.hash
+      );
+    }
+  }
+
+  /* The History API fires no event for its own calls, and marimo writes the
+     toggle back through it, so the only way to notice is to wrap them. */
+  ["pushState", "replaceState"].forEach(function (name) {
+    var original = history[name];
+    history[name] = function () {
+      var result = original.apply(this, arguments);
+      persist();
+      return result;
+    };
+  });
+  window.addEventListener("popstate", persist);
+  persist();
+})();
+</script>
+""")
+
+
+def head_script() -> str:
+    """The <head> snippet for ``marimo.create_asgi_app(html_head=...)``.
+
+    Carries the unit preference across pages and sessions in ``localStorage``,
+    seeding ``?units=`` onto the URL of a page that has the toggle before
+    marimo reads its query parameters, and writing back whatever the toggle
+    later sets.
+    """
+    return _HEAD_SCRIPT.substitute(
+        systems=json.dumps([ENGLISH, METRIC]),
+        paths=json.dumps(list(_TOGGLE_PATHS)),
+    )
 
 
 def target_unit(standard_name: str, source: str, system: str) -> str:

--- a/units.py
+++ b/units.py
@@ -1,0 +1,162 @@
+"""Unit conversion for display, free of marimo and network access.
+
+Buoy Barn (and the ERDDAP servers behind it) report each variable in whatever
+unit its instrument or provider used, not necessarily the one this dashboard
+wants to show. This module maps a CF standard name plus a source unit onto a
+metric or English display unit, converts the values, and formats a short
+label for an axis or column header.
+
+The conversion table below is transcribed from the Mariner's Dashboard
+(https://github.com/gulfofmaine/Neracoos-1-Buoy-App/tree/main/src/Features/Units)
+and deliberately covers more standard names than Buoy Barn currently exposes,
+so a newly flagged variable is already handled rather than silently falling
+back to passthrough the day it first appears.
+"""
+
+import pint
+
+import monitoring
+
+ENGLISH = "English"
+METRIC = "Metric"
+
+# ERDDAP/Buoy Barn emits degree_C, which bare pint does not define -- only
+# degC and the Celsius/celsius spellings. degree_Celsius is already a pint
+# alias for celsius and needs no define of its own.
+ureg = pint.UnitRegistry()
+ureg.define("@alias degree_Celsius = degree_C = degrees_C")
+ureg.define("@alias degree_Fahrenheit = degree_F = degrees_F")
+
+# standard_name -> (metric unit, english unit), as pint unit strings.
+TARGETS: dict[str, tuple[str, str]] = {
+    # Temperature
+    "air_temperature": ("degree_Celsius", "degree_Fahrenheit"),
+    "sea_water_temperature": ("degree_Celsius", "degree_Fahrenheit"),
+    "sea_surface_temperature": ("degree_Celsius", "degree_Fahrenheit"),
+    "dew_point_temperature": ("degree_Celsius", "degree_Fahrenheit"),
+    # Speed
+    "wind_speed": ("m/s", "knot"),
+    "wind_speed_of_gust": ("m/s", "knot"),
+    "wind_speed_sc": ("m/s", "knot"),
+    "wind_speed_ve": ("m/s", "knot"),
+    "sea_water_speed": ("m/s", "knot"),
+    "sea_water_velocity": ("m/s", "knot"),
+    "eastward_wind": ("m/s", "knot"),
+    "northward_wind": ("m/s", "knot"),
+    "eastward_sea_water_velocity": ("m/s", "knot"),
+    "northward_sea_water_velocity": ("m/s", "knot"),
+    "wind_gust": ("m/s", "knot"),
+    "wind_min": ("m/s", "knot"),
+    "wind_peak": ("m/s", "knot"),
+    # Height/level
+    "significant_wave_height": ("m", "foot"),
+    "max_wave_height": ("m", "foot"),
+    "significant_height_of_wind_and_swell_waves": ("m", "foot"),
+    "significant_height_of_wind_and_swell_waves_3": ("m", "foot"),
+    "sea_surface_wave_significant_height": ("m", "foot"),
+    "sea_water_level": ("m", "foot"),
+    "surface_altitude": ("m", "foot"),
+    "predicted_sea_water_level": ("m", "foot"),
+    "sea_surface_height_above_geopotential_datum": ("m", "foot"),
+    "tidal_sea_surface_height_above_mean_higher_high_water": ("m", "foot"),
+    "tidal_sea_surface_height_above_mean_lower_low_water": ("m", "foot"),
+    "tidal_sea_surface_height_above_mean_sea_level": ("m", "foot"),
+    # Visibility -- metric is km, not the source metres, so "metric" is not a
+    # no-op here the way it is for the other families.
+    "visibility_in_air": ("km", "nautical_mile"),
+    "min_visibility": ("km", "nautical_mile"),
+    "max_visibility": ("km", "nautical_mile"),
+    # Atmospheric pressure, in mb in both systems: mariners read mb off a
+    # barometer face, and the Mariner's Dashboard's psi for English is an
+    # oversight (issue #144). sea_water_pressure (decibars) is deliberately
+    # absent -- it is a water pressure, not an atmospheric one.
+    "barometric_pressure": ("mbar", "mbar"),
+    "air_pressure": ("mbar", "mbar"),
+    "air_pressure_at_sea_level": ("mbar", "mbar"),
+    "sea_level_pressure": ("mbar", "mbar"),
+}
+
+# Overrides applied to pint's short pretty format, keyed on the formatted
+# result. Both a millibars and an hPa source end up displayed as mb: the
+# pressure family's target is literally the string "mbar" in TARGETS above,
+# regardless of which of the two the source happened to be.
+_LABEL_OVERRIDES = {"mbar": "mb"}
+
+
+def target_unit(standard_name: str, source: str, system: str) -> str:
+    """The unit values for ``standard_name`` should be displayed in.
+
+    Passes ``source`` through unchanged for a standard name outside
+    ``TARGETS``, or when ``source`` cannot be resolved against the target
+    dimensionally -- either way there is nothing sensible to convert to.
+    """
+    entry = TARGETS.get(standard_name)
+    if entry is None:
+        return source
+    target = entry[1] if system == ENGLISH else entry[0]
+
+    try:
+        source_unit = ureg.Unit(source)
+    except (pint.UndefinedUnitError, TypeError):
+        # Bare pint raises UndefinedUnitError for a name it has never heard
+        # of, but a plain TypeError from its parser for CF-spaced compound
+        # forms like "m s-1" -- both just mean "not a unit we can use."
+        return source
+
+    try:
+        (1 * source_unit).to(target)
+    except pint.DimensionalityError as error:
+        # Source parses but its dimension doesn't match the target: Buoy Barn
+        # says one thing and this table says another, which is a real bug
+        # worth knowing about -- but not one worth crashing the dashboard over.
+        monitoring.report(
+            error,
+            where="units.target_unit",
+            level="warning",
+            standard_name=standard_name,
+            source=source,
+            target=target,
+        )
+        return source
+
+    return target
+
+
+def convert(values, source: str, target: str):
+    """Convert ``values`` (a Series or DataFrame of floats) from ``source`` to
+    ``target``, preserving index/columns/name and any NaN gaps.
+
+    Goes via a plain numpy array and pint's Quantity rather than pint-pandas'
+    dtype: that dtype leaks into to_csv/to_dict and breaks marimo's table
+    download and the vega spec, so the pandas object here is always a normal
+    float frame, just with different numbers in it.
+    """
+    if source == target:
+        return values
+
+    try:
+        source_unit = ureg.Unit(source)
+    except (pint.UndefinedUnitError, TypeError):
+        return values
+
+    # Temperature is non-multiplicative (a Celsius-to-Fahrenheit conversion is
+    # an offset, not just a scale); going through a Quantity rather than a bare
+    # Unit multiplication is what makes pint apply that offset correctly.
+    converted = (values.to_numpy() * source_unit).to(target).magnitude
+
+    if hasattr(values, "columns"):
+        return values.__class__(converted, index=values.index, columns=values.columns)
+    return values.__class__(converted, index=values.index, name=values.name)
+
+
+def label(unit: str) -> str:
+    """Short display form of ``unit`` for an axis title or column header."""
+    try:
+        formatted = f"{ureg.Unit(unit):~P}"
+    except (pint.UndefinedUnitError, TypeError):
+        return unit
+
+    formatted = _LABEL_OVERRIDES.get(formatted, formatted)
+    # pint formats the dimensionless unit "1" as an empty string, which would
+    # render an axis as "Something ()" -- fall back to the raw unit instead.
+    return formatted if formatted.strip() else unit


### PR DESCRIPTION
Adds a units toggle to the public facing charting pages. It defaults to english units, but a users preference is saved in localStorage, and shared as part of the url params.

Closes #144