### PR TITLE
Expire platform and timeseries caches at least hourly

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,6 +1,7 @@
 import base64
 import functools
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 import altair as alt
@@ -92,13 +93,33 @@ def set_defaults(page: str | None = None):
     alt.data_transformers.enable("marimo_inline_csv")
 
 
-@mo.cache
+def _cache_hour() -> str:
+    """The current UTC hour, used to cache-bust load_platform_json() and
+    load_ts() at least hourly.
+
+    mo.cache has no TTL support, so folding a time bucket into the cache key
+    is what forces cached calls to expire.
+    """
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H")
+
+
 def load_platform_json(visibility: str | None = None):
     """Load the platform JSON from the NERACOOS API.
 
-    ``visibility`` filters server side, e.g. ``"climatology"`` for the platforms
-    Buoy Barn flags as suitable for climatologies.
+    ``visibility`` filters server side, e.g. ``"climatology"`` for the
+    platforms Buoy Barn flags as suitable for climatologies. Cached per UTC
+    hour, so a change to Buoy Barn's platform list is picked up at least
+    hourly.
     """
+    return _load_platform_json(visibility, _cache_hour())
+
+
+# Only ever called with visibility=None or "climatology" -- maxsize=4 keeps
+# the current and previous hour for both without ever needing more, and
+# drops older buckets instead of retaining them forever like a plain
+# mo.cache would.
+@mo.lru_cache(maxsize=4)
+def _load_platform_json(visibility: str | None, _hour: str):
     import httpx2
 
     with monitoring.operation(
@@ -316,8 +337,11 @@ def resample_to_budget(
     return resampled, label
 
 
-@mo.cache
-def _load_ts_cached(ts: dict, col_name: str) -> pd.DataFrame:
+# Bigger key space than the platform cache (dataset x variable x depth x
+# hour), so this keeps mo.lru_cache's default maxsize=128 rather than a small
+# fixed number.
+@mo.lru_cache
+def _load_ts_cached(ts: dict, col_name: str, _hour: str) -> pd.DataFrame:
     df = load_ts_from_erddap(ts)
     df.columns = [col_name, *df.columns[1:]]
     return df
@@ -327,9 +351,11 @@ def load_ts(ts: dict, col_name: str) -> pd.DataFrame:
     """Load a timeseries with its value column named ``col_name``.
 
     Returns a fresh frame every call. Callers used to mutate what the cache
-    handed back -- dropping a column from it -- which poisoned every later read.
+    handed back -- dropping a column from it -- which poisoned every later
+    read. Cached per UTC hour, so new ERDDAP readings are picked up at least
+    hourly.
     """
-    return _load_ts_cached(ts, col_name).copy()
+    return _load_ts_cached(ts, col_name, _cache_hour()).copy()
 
 
 @functools.cache

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -5,6 +5,7 @@ conftest.py.
 """
 
 import altair as alt
+import httpx2
 import pandas as pd
 import pytest
 import sentry_sdk
@@ -436,6 +437,90 @@ def test_load_ts_hands_back_a_fresh_frame_each_call():
     second = common.load_ts(NDBC_SST, "Sea Surface Temperature")
 
     assert "Sea Surface Temperature" in second.columns
+
+
+class FakePlatformResponse:
+    """Stands in for the httpx2 response ``_load_platform_json`` reads."""
+
+    status_code = 200
+
+    def json(self):
+        return {"features": []}
+
+
+def test_load_platform_json_caches_within_the_same_hour(monkeypatch):
+    # mo.lru_cache is a real, process-wide cache (not reset between tests), so
+    # a stale entry from another test using the same fixed hour string would
+    # otherwise make this test order-dependent.
+    common._load_platform_json.cache_clear()
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakePlatformResponse()
+
+    monkeypatch.setattr(httpx2, "get", fake_get)
+    monkeypatch.setattr(common, "_cache_hour", lambda: "2026-08-18T00")
+
+    common.load_platform_json()
+    common.load_platform_json()
+
+    assert len(calls) == 1
+
+
+def test_load_platform_json_refetches_on_a_new_hour(monkeypatch):
+    common._load_platform_json.cache_clear()
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakePlatformResponse()
+
+    monkeypatch.setattr(httpx2, "get", fake_get)
+
+    monkeypatch.setattr(common, "_cache_hour", lambda: "2026-08-18T00")
+    common.load_platform_json()
+
+    monkeypatch.setattr(common, "_cache_hour", lambda: "2026-08-18T01")
+    common.load_platform_json()
+
+    assert len(calls) == 2
+
+
+def test_load_ts_caches_within_the_same_hour(monkeypatch):
+    common._load_ts_cached.cache_clear()
+    calls = []
+
+    def fake_load_ts_from_erddap(ts):
+        calls.append(ts)
+        return erddap_frame(3)
+
+    monkeypatch.setattr(common, "load_ts_from_erddap", fake_load_ts_from_erddap)
+    monkeypatch.setattr(common, "_cache_hour", lambda: "2026-08-18T00")
+
+    common.load_ts(NDBC_SST, "Sea Surface Temperature")
+    common.load_ts(NDBC_SST, "Sea Surface Temperature")
+
+    assert len(calls) == 1
+
+
+def test_load_ts_refetches_on_a_new_hour(monkeypatch):
+    common._load_ts_cached.cache_clear()
+    calls = []
+
+    def fake_load_ts_from_erddap(ts):
+        calls.append(ts)
+        return erddap_frame(3)
+
+    monkeypatch.setattr(common, "load_ts_from_erddap", fake_load_ts_from_erddap)
+
+    monkeypatch.setattr(common, "_cache_hour", lambda: "2026-08-18T00")
+    common.load_ts(NDBC_SST, "Sea Surface Temperature")
+
+    monkeypatch.setattr(common, "_cache_hour", lambda: "2026-08-18T01")
+    common.load_ts(NDBC_SST, "Sea Surface Temperature")
+
+    assert len(calls) == 2
 
 
 def test_admonition_offers_no_report_link_without_a_dsn(monkeypatch):


### PR DESCRIPTION
Configures the cache to be cleared hourly, so that platform changes don’t require a new deployement before they are visible