### PR TITLE
Hide the tools other than climatology from the sidebar

### DIFF
--- a/common.py
+++ b/common.py
@@ -557,14 +557,14 @@ def sidebar_menu(unit_toggle=None):
                         "https://data.neracoos.org/thredds/": {"label": "THREDDS"},
                     },
                     f"{mo.icon('streamline-ultimate:analytics-graph-lines-2')} Visualize and Compare": {
-                        "/by_platform": {
-                            "label": "By Buoy",
-                            "description": "Graph and download multiple data types for a buoy",
-                        },
-                        "/by_standard_name": {
-                            "label": "By Data Type",
-                            "description": "Compare the same type of data across multiple buoys",
-                        },
+                        # "/by_platform": {
+                        #     "label": "By Buoy",
+                        #     "description": "Graph and download multiple data types for a buoy",
+                        # },
+                        # "/by_standard_name": {
+                        #     "label": "By Data Type",
+                        #     "description": "Compare the same type of data across multiple buoys",
+                        # },
                         "/climatology": {
                             "label": "Climatology",
                             "description": "View climatology for buoys",

--- a/root.py
+++ b/root.py
@@ -26,12 +26,13 @@ def _(common):
 @app.cell
 def _():
     button_style = "display: inline-block; background-color: rgb(23, 133, 150); border-radius: 3px; padding: .5rem; text-align: center; color: white"
+    preview_button_style = "display: inline-block; background-color: #ffcb22; border-radius: 3px; padding: .5rem; text-align: center; color: black"
     column_style = "margin: 1rem; min-width: 200px"
-    return button_style, column_style
+    return button_style, column_style, preview_button_style
 
 
 @app.cell
-def _(button_style, column_style, mo):
+def _(button_style, column_style, preview_button_style, mo):
     mo.md(
         f"""
     # NERACOOS Data Products
@@ -76,13 +77,24 @@ def _(button_style, column_style, mo):
 
     <div style="display: flex">
         <div style="{column_style}">
+            <a href="/climatology/">
+                <h3>Climatology</h3>
+            </a>
+            <p>Compare recent conditions to historical norms at buoy locations.</p>
+            <a href="/climatology/">
+                <button style="{button_style}">
+                    View
+                </button>
+            </a>
+        </div>
+        <div style="{column_style}">
             <a href="/by_platform/">
                 <h3>By Buoy</h3>
             </a>
             <p>Visualize, compare, and download multiple data types by buoy.</p>
             <a href="/by_platform/">
-                <button style="{button_style}">
-                    View
+                <button style="{preview_button_style}">
+                    Preview
                 </button>
             </a>
         </div>
@@ -92,19 +104,8 @@ def _(button_style, column_style, mo):
             </a>
             <p>Visualize, compare, and download the same data type across multiple buoys.</p>
             <a href="/by_standard_name/">
-                <button style="{button_style}">
-                    View
-                </button>
-            </a>
-        </div>
-        <div style="{column_style}">
-            <a href="/climatology/">
-                <h3>Climatology</h3>
-            </a>
-            <p>Compare recent conditions to historical norms at buoy locations.</p>
-            <a href="/climatology/">
-                <button style="{button_style}">
-                    View
+                <button style="{preview_button_style}">
+                    Preview
                 </button>
             </a>
         </div>

--- a/tests/e2e/test_by_platform.py
+++ b/tests/e2e/test_by_platform.py
@@ -10,9 +10,7 @@ from playwright.sync_api import Page, expect
 
 
 def test_western_maine_shelf(page: Page) -> None:
-    page.goto("/")
-    page.get_by_role("navigation").get_by_role("link", name="By Buoy").click()
-    expect(page).to_have_url("/by_platform/")
+    page.goto("/by_platform/")
     page.get_by_test_id("marimo-plugin-dropdown").select_option(
         "B01 - Western Maine Shelf",
     )

--- a/tests/e2e/test_by_standard_name.py
+++ b/tests/e2e/test_by_standard_name.py
@@ -10,8 +10,7 @@ from playwright.sync_api import Page, expect
 
 
 def test_air_temp(page: Page) -> None:
-    page.goto("/")
-    page.get_by_role("navigation").get_by_role("link", name="By Data Type").click()
+    page.goto("/by_standard_name/")
     expect(
         page.get_by_role("heading", name="Visualize and Compare by Data"),
     ).to_be_visible()


### PR DESCRIPTION
It also marks them as preview on the root page.