### PR TITLE
Handle standard_names with non-standard units

### DIFF
--- a/by_standard_name.py
+++ b/by_standard_name.py
@@ -134,21 +134,24 @@ def _(standard_name_dropdown, standards, units_radio):
             ),
         )
 
-    # Every platform on this page reports the same standard name, and no
-    # standard name Buoy Barn serves is spelled with more than one unit
-    # string, so one source unit covers the whole comparison.
-    source_unit = _data_type["units"]
-    target_unit = units.target_unit(
-        standard_name_dropdown.value,
-        source_unit,
-        units_radio.value,
+    # Buoy Barn does not guarantee every platform spells this standard name's
+    # unit the same way (e.g. air_temperature: "celsius" almost everywhere,
+    # bare "F" -- which pint parses as Farad, not Fahrenheit -- on one
+    # platform) -- units.display_unit() reads the target straight out of
+    # TARGETS instead of validating against whichever platform's data_type
+    # happened to land in standards[...], so one bad platform's spelling
+    # can't clobber the label, or (via convert() below, per platform) the
+    # values, for every other platform on the page.
+    target_unit = (
+        units.display_unit(standard_name_dropdown.value, units_radio.value)
+        or _data_type["units"]
     )
     # ``unit`` names the melted frame's value column, which is also the chart's
     # y encoding and the tooltip's field, so the display label reaches all
     # three by being this one string.
     unit = units.label(target_unit)
     monitoring.tag_context(units=units_radio.value)
-    return source_unit, target_unit, unit
+    return target_unit, unit
 
 
 @app.cell
@@ -166,7 +169,6 @@ def _(selected_ts_keys):
 def _(
     platform_options,
     selected_ts_keys,
-    source_unit,
     standard_name_dropdown,
     target_unit,
     unit,
@@ -198,13 +200,20 @@ def _(
                     continue
                 if not _df.index.is_unique:
                     _df = _df.loc[~_df.index.duplicated(keep="first")]
+                # Converted per platform, not once over the whole concatenated
+                # frame: Buoy Barn does not guarantee every platform spells
+                # this standard name's unit the same way, and convert() safely
+                # no-ops a platform whose own spelling doesn't match
+                # target_unit rather than mis-converting it under another
+                # platform's units.
+                _df[_ts_name] = units.convert(
+                    _df[_ts_name],
+                    _ts["data_type"]["units"],
+                    target_unit,
+                )
                 _wide_dfs.append(_df)
 
             wide_df = pd.concat(_wide_dfs, axis=1)
-            # Converted once, here, rather than per platform: every column is
-            # the same standard name in the same source unit, and both
-            # accordion downloads below hang off this frame.
-            wide_df = units.convert(wide_df, source_unit, target_unit)
             wide_melted = pd.melt(wide_df.reset_index(), id_vars="time (UTC)")
             wide_melted = wide_melted.rename(
                 columns={"variable": "Timeseries", "value": unit},

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -224,6 +224,46 @@ def test_resolved_dimensionality_mismatch_is_then_a_no_op_conversion():
     assert result.tolist() == [1.0, 2.0]
 
 
+def test_display_unit_reads_targets_for_both_systems():
+    assert units.display_unit("air_temperature", units.ENGLISH) == "degree_Fahrenheit"
+    assert units.display_unit("air_temperature", units.METRIC) == "degree_Celsius"
+
+
+def test_display_unit_is_none_outside_targets():
+    assert units.display_unit("some_unknown_standard_name", units.ENGLISH) is None
+
+
+def test_convert_passes_through_an_unresolved_dimensionality_mismatch():
+    """A platform's bare "F" parses fine (pint reads it as Farad) but is not
+    dimensionally compatible with a Fahrenheit target -- unlike
+    test_resolved_dimensionality_mismatch_is_then_a_no_op_conversion above,
+    this pair was never pre-resolved through target_unit(), so convert() must
+    catch the mismatch itself rather than propagate pint's error."""
+    values = pd.Series([1.0, 2.0])
+
+    result = units.convert(values, "F", "degree_Fahrenheit")
+
+    assert result.tolist() == [1.0, 2.0]
+
+
+def test_convert_dimensionality_mismatch_reports_to_monitoring(monkeypatch):
+    reported = {}
+
+    def fake_report(error, *, where, level, **tags):
+        reported["error"] = error
+        reported["where"] = where
+        reported["level"] = level
+        reported["tags"] = tags
+
+    monkeypatch.setattr(units.monitoring, "report", fake_report)
+
+    units.convert(pd.Series([1.0, 2.0]), "F", "degree_Fahrenheit")
+
+    assert reported["where"] == "units.convert"
+    assert reported["level"] == "warning"
+    assert reported["tags"] == {"source": "F", "target": "degree_Fahrenheit"}
+
+
 def test_nan_survives_a_conversion():
     values = pd.Series([0.0, np.nan, 21.5])
 

--- a/units.py
+++ b/units.py
@@ -214,6 +214,28 @@ def target_unit(standard_name: str, source: str, system: str) -> str:
     return target
 
 
+def display_unit(standard_name: str, system: str) -> str | None:
+    """The unit ``standard_name`` should always be displayed in, independent
+    of any single source's spelling.
+
+    Reads straight out of ``TARGETS`` rather than validating against a live
+    source the way ``target_unit()`` does -- ``TARGETS``'s two entries per
+    standard name are curated and tested as a dimensionally-compatible pair
+    (see test_units.py), so there is nothing to gain by re-checking them
+    against one arbitrary platform's reported spelling, and doing so is
+    actively harmful if that platform's spelling happens to be bad (see
+    by_standard_name.py, which uses this to avoid exactly that).
+
+    Returns ``None`` for a standard name outside ``TARGETS`` -- the caller
+    then has no authoritative unit and must fall back to a live source's own
+    reported spelling.
+    """
+    entry = TARGETS.get(standard_name)
+    if entry is None:
+        return None
+    return entry[1] if system == ENGLISH else entry[0]
+
+
 def convert(values, source: str, target: str):
     """Convert ``values`` (a Series or DataFrame of floats) from ``source`` to
     ``target``, preserving index/columns/name and any NaN gaps.
@@ -222,6 +244,11 @@ def convert(values, source: str, target: str):
     dtype: that dtype leaks into to_csv/to_dict and breaks marimo's table
     download and the vega spec, so the pandas object here is always a normal
     float frame, just with different numbers in it.
+
+    A ``source`` that parses fine but is dimensionally incompatible with
+    ``target`` (e.g. a platform's bare "F" -- parsed by pint as Farad, not
+    Fahrenheit -- against a Fahrenheit target) is handled the same way an
+    unparsable ``source`` is: passthrough, with a monitoring report.
     """
     if source == target:
         return values
@@ -234,7 +261,17 @@ def convert(values, source: str, target: str):
     # Temperature is non-multiplicative (a Celsius-to-Fahrenheit conversion is
     # an offset, not just a scale); going through a Quantity rather than a bare
     # Unit multiplication is what makes pint apply that offset correctly.
-    converted = (values.to_numpy() * source_unit).to(target).magnitude
+    try:
+        converted = (values.to_numpy() * source_unit).to(target).magnitude
+    except pint.DimensionalityError as error:
+        monitoring.report(
+            error,
+            where="units.convert",
+            level="warning",
+            source=source,
+            target=target,
+        )
+        return values
 
     if hasattr(values, "columns"):
         return values.__class__(converted, index=values.index, columns=values.columns)


### PR DESCRIPTION
Looking at you Stone Living Lab. `air_temperature` `standard_name` in F in ERDDAP? Why do you want to see the world burn?